### PR TITLE
Adding clarification to tutorial docs for obtaining output yaml files.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,12 @@ export PIPESTAT_RECORD_ID=my_record
 export PIPESTAT_RESULTS_FILE=results_file.yaml
 export PIPESTAT_NAMESPACE=my_namespace
 ```
+Note: When setting environment variables as in the above example, you will need to provide an output_schema.yaml file in your current working directory with the following example data:
+```
+result_name:
+  type: string
+  description: "Result Name"
+```
 
 ## Pipeline results reporting and retrieval
 

--- a/docs_jupyter/cli.ipynb
+++ b/docs_jupyter/cli.ipynb
@@ -6,15 +6,16 @@
    "source": [
     "# Pipestat CLI\n",
     "\n",
-    "This tutorial demonstrates how to use the pipeline command-line interface (CLI). You should have already installed pipestat. **Before following this tutorial please make sure you're familiar with more information-rich \"Pipestat Python API\" tutorial.**"
+    "This tutorial demonstrates how to use the pipeline command-line interface (CLI). You should have already installed pipestat. **Before following this tutorial please make sure you're familiar with more information-rich \"Pipestat Python API\" tutorial.** \n",
+    "Also, for the following tutorial, you will need to point to a **sample_output_schema.yaml** in the schema path. An example file can be found here: https://github.com/pepkit/pipestat/blob/master/tests/data/sample_output_schema.yaml"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Report results from the command line by calling `pipestat` and passing in all relevant information:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -22,8 +23,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Reported records for 'sample_name' in 'pipeline_name' namespace:\n",
       " - percentage_of_things: 12\n"
@@ -88,8 +89,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "number_of_things:\n",
       "  type: integer\n",
@@ -141,8 +142,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Reported records for 'sample1' in 'test' namespace:\n",
       " - number_of_things: 100\n"
@@ -166,8 +167,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "test:\n",
       "  sample1:\n",
@@ -192,8 +193,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Reported records for 'sample1' in 'test' namespace:\n",
       " - percentage_of_things: 1.1\n"
@@ -210,8 +211,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "test:\n",
       "  sample1:\n",
@@ -239,8 +240,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "\n",
@@ -272,8 +273,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "\n",
@@ -313,8 +314,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "1.1\n"
      ]
@@ -339,8 +340,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Removed result 'percentage_of_things' for record 'sample1' from 'test' namespace\n"
      ]
@@ -363,8 +364,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "test:\n",
       "  sample1:\n",
@@ -382,8 +383,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "\n",
@@ -436,8 +437,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "running\n"
      ]
@@ -448,11 +449,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Note that only statuses defined in the status schema are supported:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -460,8 +461,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "running:\n",
       "  description: \"the pipeline is running\"\n",

--- a/docs_jupyter/python_api.ipynb
+++ b/docs_jupyter/python_api.ipynb
@@ -63,8 +63,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "/var/folders/h8/8npwnh2s4rb8lr6hsy2ydrsh0000gp/T/tmpjupp4wcz.yaml\n"
      ]
@@ -102,6 +102,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note: For schema_path, you will need to point to a **sample_output_schema.yaml**. An example file can be found here: https://github.com/pepkit/pipestat/blob/master/tests/data/sample_output_schema.yaml\n",
+    "\n",
     "You can also put these settings into a config file and just pass that to the `config` argument, instead of specifying each argument separately. The results will be reported to a \"test\" namespace."
    ]
   },
@@ -111,14 +113,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'test'"
       ]
      },
+     "execution_count": 242,
      "metadata": {},
-     "execution_count": 242
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -138,14 +140,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'sample1'"
       ]
      },
+     "execution_count": 243,
      "metadata": {},
-     "execution_count": 243
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -165,14 +167,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "YacAttMap: {}"
       ]
      },
+     "execution_count": 244,
      "metadata": {},
-     "execution_count": 244
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -206,7 +208,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "{'number_of_things': {'type': 'integer', 'description': 'Number of things'},\n",
@@ -226,8 +227,9 @@
        "  'highlight': True}}"
       ]
      },
+     "execution_count": 245,
      "metadata": {},
-     "execution_count": 245
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -247,7 +249,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "{'type': 'object',\n",
@@ -256,8 +257,9 @@
        " 'required': ['path', 'title']}"
       ]
      },
+     "execution_count": 246,
      "metadata": {},
-     "execution_count": 246
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -278,10 +280,20 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "'title' is a required property\n\nFailed validating 'required' in schema:\n    {'description': 'This a path to the output file',\n     'properties': {'path': {'type': 'string'},\n                    'title': {'type': 'string'}},\n     'required': ['path', 'title'],\n     'type': 'object'}\n\nOn instance:\n    {'path': '/home/user/path.csv'}\n"
+      "'title' is a required property\n",
+      "\n",
+      "Failed validating 'required' in schema:\n",
+      "    {'description': 'This a path to the output file',\n",
+      "     'properties': {'path': {'type': 'string'},\n",
+      "                    'title': {'type': 'string'}},\n",
+      "     'required': ['path', 'title'],\n",
+      "     'type': 'object'}\n",
+      "\n",
+      "On instance:\n",
+      "    {'path': '/home/user/path.csv'}\n"
      ]
     }
    ],
@@ -305,21 +317,22 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "Reported records for 'sample1' in 'test' namespace:\n - output_file: {'path': '/home/user/path.csv', 'title': 'CSV file with some data'}\n"
+      "Reported records for 'sample1' in 'test' namespace:\n",
+      " - output_file: {'path': '/home/user/path.csv', 'title': 'CSV file with some data'}\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "True"
       ]
      },
+     "execution_count": 248,
      "metadata": {},
-     "execution_count": 248
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -346,7 +359,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "test:\n",
@@ -356,8 +368,9 @@
        "      title: CSV file with some data"
       ]
      },
+     "execution_count": 249,
      "metadata": {},
-     "execution_count": 249
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -377,21 +390,21 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "These results exist for 'sample1': output_file\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "False"
       ]
      },
+     "execution_count": 250,
      "metadata": {},
-     "execution_count": 250
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -411,8 +424,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "These results exist for 'sample1': output_file\n",
       "Overwriting existing results: output_file\n",
@@ -421,7 +434,6 @@
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "test:\n",
@@ -431,8 +443,9 @@
        "      title: new CSV file with some data"
       ]
      },
+     "execution_count": 251,
      "metadata": {},
-     "execution_count": 251
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -475,7 +488,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "test:\n",
@@ -485,8 +497,9 @@
        "      title: new CSV file with some data"
       ]
      },
+     "execution_count": 253,
      "metadata": {},
-     "execution_count": 253
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -506,8 +519,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "/var/folders/h8/8npwnh2s4rb8lr6hsy2ydrsh0000gp/T/tmpjupp4wcz.yaml\n",
       "test:\n",
@@ -542,14 +555,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "{'type': 'integer', 'description': 'Number of things'}"
       ]
      },
+     "execution_count": 255,
      "metadata": {},
-     "execution_count": 255
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -562,21 +575,22 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "Reported records for 'sample1' in 'test' namespace:\n - number_of_things: 10\n"
+      "Reported records for 'sample1' in 'test' namespace:\n",
+      " - number_of_things: 10\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "True"
       ]
      },
+     "execution_count": 256,
      "metadata": {},
-     "execution_count": 256
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -596,8 +610,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "int() argument must be a string, a bytes-like object or a number, not 'list'\n"
      ]
@@ -625,7 +639,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "test:\n",
@@ -636,8 +649,9 @@
        "    number_of_things: 10"
       ]
      },
+     "execution_count": 258,
      "metadata": {},
-     "execution_count": 258
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -661,14 +675,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'10'"
       ]
      },
+     "execution_count": 259,
      "metadata": {},
-     "execution_count": 259
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -688,7 +702,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "{'output_file': {'path': '/home/user/path_new.csv',\n",
@@ -696,8 +709,9 @@
        " 'number_of_things': '10'}"
       ]
      },
+     "execution_count": 260,
      "metadata": {},
-     "execution_count": 260
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -724,21 +738,21 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "Removed result 'number_of_things' for record 'sample1' from 'test' namespace\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "True"
       ]
      },
+     "execution_count": 261,
      "metadata": {},
-     "execution_count": 261
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -758,21 +772,21 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "Removing 'sample1' record\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "True"
       ]
      },
+     "execution_count": 262,
      "metadata": {},
-     "execution_count": 262
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -796,14 +810,14 @@
    },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "test: OrderedDict()"
       ]
      },
+     "execution_count": 263,
      "metadata": {},
-     "execution_count": 263
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -825,8 +839,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "/var/folders/h8/8npwnh2s4rb8lr6hsy2ydrsh0000gp/T/tmpshtnle33.yaml\n"
      ]
@@ -859,7 +873,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "{'number_of_things': {'type': 'integer', 'description': 'Number of things'},\n",
@@ -889,8 +902,9 @@
        "  'description': 'Pipeline version'}}"
       ]
      },
+     "execution_count": 265,
      "metadata": {},
-     "execution_count": 265
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -910,14 +924,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "['log', 'profile', 'commands', 'version']"
       ]
      },
+     "execution_count": 266,
      "metadata": {},
-     "execution_count": 266
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -957,14 +971,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'running'"
       ]
      },
+     "execution_count": 268,
      "metadata": {},
-     "execution_count": 268
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -984,7 +998,6 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "{'running': {'description': 'the pipeline is running',\n",
@@ -998,8 +1011,9 @@
        "  'color': [169, 169, 169]}}"
       ]
      },
+     "execution_count": 269,
      "metadata": {},
-     "execution_count": 269
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1032,8 +1046,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "/var/folders/h8/8npwnh2s4rb8lr6hsy2ydrsh0000gp/T/tmpauamyheb.yaml\n"
      ]
@@ -1061,8 +1075,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Results schema not found. The schema is required to report results. It needs to be supplied to the object constructor or via 'PIPESTAT_RESULTS_SCHEMA' environment variable.\n"
      ]
@@ -1088,14 +1102,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'running'"
       ]
      },
+     "execution_count": 272,
      "metadata": {},
-     "execution_count": 272
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1105,9 +1119,13 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "ac2eaa0ea0ebeafcc7822e65e46aa9d4f966f30b695406963e145ea4a91cd4fc"
+  },
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.9.5 64-bit ('python@3.9')"
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1119,10 +1137,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
-  },
-  "interpreter": {
-   "hash": "ac2eaa0ea0ebeafcc7822e65e46aa9d4f966f30b695406963e145ea4a91cd4fc"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/pipestat/demo.py
+++ b/pipestat/demo.py
@@ -13,32 +13,29 @@ yam.to_dict()
 
 # Create the table column definitions matching this schema
 sample_field_definitions = {
-	"id": (Optional[int], Field(default=None, primary_key=True)),
+    "id": (Optional[int], Field(default=None, primary_key=True)),
 }
 for element in yam["properties"]["samples"]["items"]["properties"]:
-	sample_field_definitions[element] = (Optional[str], Field(default=None))
+    sample_field_definitions[element] = (Optional[str], Field(default=None))
 
 project_field_definitions = {}
 for element in yam["properties"]:
-	if element == "samples":
-		continue
-	project_field_definitions[element] = (Optional[str], Field(default=None))
+    if element == "samples":
+        continue
+    project_field_definitions[element] = (Optional[str], Field(default=None))
 
 # Build a SQLModel for this JSON-schema
 Sample = create_model(
-	f"{yam['pipeline_id']}_sample", # Name of table
-	__base__=SQLModel,
-	__cls_kwargs__={"table": True},  # Specifies this for SQLModel table
-	**sample_field_definitions
-	)
+    f"{yam['pipeline_id']}_sample",  # Name of table
+    __base__=SQLModel,
+    __cls_kwargs__={"table": True},  # Specifies this for SQLModel table
+    **sample_field_definitions,
+)
 
-Project = create_model(
-	f"{yam['pipeline_id']}_project",
-	**project_field_definitions
-	)
+Project = create_model(f"{yam['pipeline_id']}_project", **project_field_definitions)
 
 
-sample_instance = {"smooth_bw":"path/to/smooth_bw.bw"}
+sample_instance = {"smooth_bw": "path/to/smooth_bw.bw"}
 project_instance = {"number_of_things": 15}
 
 
@@ -75,7 +72,6 @@ print(s1)
 print(s2)
 
 
-
 # Retrieve a sample from the database like this
 session.get(Sample, 2)
 
@@ -84,6 +80,6 @@ session.exec(select(Sample)).all()
 
 # A generator that iterates through samples
 
-def sample_iter():
-	...
 
+def sample_iter():
+    ...

--- a/tests/data/output_schema.yaml
+++ b/tests/data/output_schema.yaml
@@ -1,0 +1,3 @@
+result_name:
+  type: string
+  description: "ResultName"

--- a/tests/data/sample_output_schema.yaml
+++ b/tests/data/sample_output_schema.yaml
@@ -7,7 +7,7 @@ percentage_of_things:
 name_of_something:
   type: string
   description: "Name of something"
-swtich_value:
+switch_value:
   type: boolean
   description: "Is the switch on of off"
 collection_of_things:


### PR DESCRIPTION
Added clarifications surrounding the yaml files needed to follow along with the various tutorials. I did **not** rewrite any of the tutorials, only added some clarification to help with path confusion per issue https://github.com/pepkit/pipestat/issues/28

Does this sufficiently tackle the issue or should more of the tutorial be rewritten with more explicit instructions?