### PR TITLE
implement require backend decorator

### DIFF
--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -24,6 +24,17 @@ _LOGGER = getLogger(PKG_NAME)
 from .backend import FileBackend, DBBackend
 
 
+def require_backend(func):
+    """Decorator to ensure a backend exists for functions that require one"""
+
+    def inner(self, *args, **kwargs):
+        if not self.backend:
+            raise NoBackendSpecifiedError
+        return func(self, *args, **kwargs)
+
+    return inner
+
+
 class PipestatManager(dict):
     """
     Pipestat standardizes reporting of pipeline results and
@@ -414,6 +425,7 @@ class PipestatManager(dict):
                 f"Neither project nor samples model could be built from schema source: {self.status_schema_source}"
             )
 
+    @require_backend
     def set_status(
         self,
         status_identifier: str,
@@ -434,11 +446,7 @@ class PipestatManager(dict):
         :param str pipeline_type: "sample" or "project"
         """
         pipeline_type = pipeline_type or self.pipeline_type
-
-        if self.backend:
-            self.backend.set_status(status_identifier, record_identifier, pipeline_type)
-        else:
-            raise NoBackendSpecifiedError
+        self.backend.set_status(status_identifier, record_identifier, pipeline_type)
 
     def get_status_flag_path(self, status_identifier: str, record_identifier=None) -> str:
         """
@@ -458,6 +466,7 @@ class PipestatManager(dict):
             self[STATUS_FILE_DIR], f"{self.namespace}_{r_id}_{status_identifier}.flag"
         )
 
+    @require_backend
     def get_status(
         self, record_identifier: str = None, pipeline_type: Optional[str] = None
     ) -> Optional[str]:
@@ -469,11 +478,9 @@ class PipestatManager(dict):
         """
         r_id = self._strict_record_id(record_identifier)
         pipeline_type = pipeline_type or self.pipeline_type
-        if self.backend:
-            return self.backend.get_status(record_identifier=r_id, pipeline_type=pipeline_type)
-        else:
-            raise NoBackendSpecifiedError
+        return self.backend.get_status(record_identifier=r_id, pipeline_type=pipeline_type)
 
+    @require_backend
     def clear_status(
         self, record_identifier: str = None, flag_names: List[str] = None
     ) -> List[Union[str, None]]:
@@ -486,11 +493,7 @@ class PipestatManager(dict):
         :return List[str]: Collection of names of flags removed
         """
         r_id = self._strict_record_id(record_identifier)
-
-        if self.backend:
-            return self.backend.clear_status(record_identifier=r_id, flag_names=flag_names)
-        else:
-            raise NoBackendSpecifiedError
+        return self.backend.clear_status(record_identifier=r_id, flag_names=flag_names)
 
     def validate_schema(self) -> None:
         """
@@ -582,6 +585,7 @@ class PipestatManager(dict):
         """
         return self.get(attr)
 
+    @require_backend
     def count_records(self, pipeline_type: Optional[str] = None) -> int:
         """
         Count records
@@ -589,13 +593,9 @@ class PipestatManager(dict):
         :return int: number of records
         """
         pipeline_type = pipeline_type or self.pipeline_type
-        if self.backend:
-            result = self.backend.count_records(pipeline_type)
-        else:
-            raise NoBackendSpecifiedError
+        return self.backend.count_records(pipeline_type)
 
-        return result
-
+    @require_backend
     def select(
         self,
         table_name: Optional[str] = None,
@@ -627,22 +627,17 @@ class PipestatManager(dict):
         :return List [Any]: list of results
         """
         pipeline_type = pipeline_type or self.pipeline_type
+        return self.backend.select(
+            table_name,
+            columns,
+            filter_conditions,
+            json_filter_conditions,
+            offset,
+            limit,
+            pipeline_type,
+        )
 
-        if self.backend:
-            result = self.backend.select(
-                table_name,
-                columns,
-                filter_conditions,
-                json_filter_conditions,
-                offset,
-                limit,
-                pipeline_type,
-            )
-        else:
-            raise NoBackendSpecifiedError
-
-        return result
-
+    @require_backend
     def select_distinct(
         self,
         table_name,
@@ -658,15 +653,11 @@ class PipestatManager(dict):
         :return List[Any]: list of results
         """
         pipeline_type = pipeline_type or self.pipeline_type
-        if self.backend:
-            result = self.backend.select_distinct(
-                table_name=table_name, columns=columns, pipeline_type=pipeline_type
-            )
-        else:
-            raise NoBackendSpecifiedError
+        return self.backend.select_distinct(
+            table_name=table_name, columns=columns, pipeline_type=pipeline_type
+        )
 
-        return result
-
+    @require_backend
     def retrieve(
         self,
         record_identifier: Optional[str] = None,
@@ -690,19 +681,16 @@ class PipestatManager(dict):
 
         record_identifier = self._strict_record_id(record_identifier)
         # should change to simpler: record_identifier = record_identifier or self.record_identifier
-        if self.backend:
-            if self.file is None:
-                results = self.backend.retrieve(
-                    record_identifier, result_identifier, pipeline_type
-                )
-                if result_identifier is not None:
-                    return results[result_identifier]
-                return results
-            else:
-                return self.backend.retrieve(record_identifier, result_identifier, pipeline_type)
-        else:
-            raise NoBackendSpecifiedError
 
+        if self.file is None:
+            results = self.backend.retrieve(record_identifier, result_identifier, pipeline_type)
+            if result_identifier is not None:
+                return results[result_identifier]
+            return results
+        else:
+            return self.backend.retrieve(record_identifier, result_identifier, pipeline_type)
+
+    @require_backend
     def select_txt(
         self,
         columns: Optional[List[str]] = None,
@@ -730,14 +718,9 @@ class PipestatManager(dict):
         :return List[Any]: a list of matched records
         """
         pipeline_type = pipeline_type or self.pipeline_type
-        if self.backend:
-            results = self.backend.select_txt(
-                columns, filter_templ, filter_params, table_name, offset, limit, pipeline_type
-            )
-        else:
-            raise NoBackendSpecifiedError
-
-        return results
+        return self.backend.select_txt(
+            columns, filter_templ, filter_params, table_name, offset, limit, pipeline_type
+        )
 
     def report(
         self,
@@ -800,6 +783,7 @@ class PipestatManager(dict):
         _LOGGER.info(record_identifier, values)
         return True if not return_id else updated_ids
 
+    @require_backend
     def remove(
         self,
         record_identifier: str = None,
@@ -822,7 +806,4 @@ class PipestatManager(dict):
         pipeline_type = pipeline_type or self.pipeline_type
 
         r_id = self._strict_record_id(record_identifier)
-        if self.backend:
-            return self.backend.remove(record_identifier, result_identifier, pipeline_type)
-        else:
-            raise NoBackendSpecifiedError
+        return self.backend.remove(record_identifier, result_identifier, pipeline_type)


### PR DESCRIPTION
This change saves us some code by abstracting away the common need to confirm a backend exists into a Python decorator that can be applied to all methods that require the backend to exist.

Can you confirm that this is what you want, and see if there are any other places you could simplify the code by applying this proposed decorator?