### PR TITLE
Align Pipestat output schema with looper output schema

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,10 @@ coverage:
         target: 80%    # the required coverage value
         threshold: 1%  # the leniency in hitting the target
         informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
 ignore:
   - "*/argparser.py"
   - "*/cli.py"

--- a/pipestat/parsed_schema.py
+++ b/pipestat/parsed_schema.py
@@ -91,9 +91,11 @@ class ParsedSchema(object):
         self._status_data = _safe_pop_one_mapping(key="status", data=data, info_name="status")
 
         if data:
-            raise SchemaError(
-                f"Extra top-level key(s) in given schema data: {', '.join(data.keys())}"
+            _LOGGER.info(
+                "Top-Level arguments found in output schema. They will be assigned to project-level."
             )
+            extra_project_data = _recursively_replace_custom_types(data)
+            self._project_level_data.update(extra_project_data)
 
         # Check that no reserved keywords were used as data items.
         resv_kwds = {"id", SAMPLE_NAME}

--- a/tests/test_parsed_schema.py
+++ b/tests/test_parsed_schema.py
@@ -197,13 +197,6 @@ SCHEMA_DATA_TUPLES_WITHOUT_PIPELINE_NAME = [
             f"Could not find valid pipeline identifier (key '{SCHEMA_PIPELINE_NAME_KEY}') in given schema data",
         )
         for data in SCHEMA_DATA_TUPLES_WITHOUT_PIPELINE_NAME
-    ]
-    + [
-        (
-            dict(data + [(SCHEMA_PIPELINE_NAME_KEY, "test_pipe"), ("extra_key", "placeholder")]),
-            "Extra top-level key(s) in given schema data: extra_key",
-        )
-        for data in SCHEMA_DATA_TUPLES_WITHOUT_PIPELINE_NAME
     ],
 )
 def test_insufficient_schema__raises_expected_error_and_message(schema_data, expected_message):


### PR DESCRIPTION
Addresses https://github.com/pepkit/pipestat/issues/20

From previous discussion: if items are present but not defined under `samples`, they should be assumed to be `project-level`.

Therefore, this PR takes those extra top-level arguments and adds them to the project level.