### PR TITLE
Add retrieve_multiple to backends

### DIFF
--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -191,6 +191,14 @@ class PipestatBackend(ABC):
         limit: Optional[int] = 1000,
         offset: Optional[int] = 0,
     ) -> Union[Any, Dict[str, Any]]:
+        """
+        :param List[str] record_identifier: list of record identifiers
+        :param List[str] result_identifier: list of result identifiers to be retrieved
+        :param int limit: limit number of records to this amount
+        :param int offset: offset records by this amount
+        :return Dict[str, any]: a mapping with filtered results reported for the record
+        """
+
         _LOGGER.warning("Not implemented yet for this backend")
         pass
 

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -184,6 +184,16 @@ class PipestatBackend(ABC):
         _LOGGER.warning("Not implemented yet for this backend")
         pass
 
+    def retrieve_multiple(
+        self,
+        record_identifier: Optional[List[str]] = None,
+        result_identifier: Optional[List[str]] = None,
+        limit: Optional[int] = 1000,
+        offset: Optional[int] = 0,
+    ) -> Union[Any, Dict[str, Any]]:
+        _LOGGER.warning("Not implemented yet for this backend")
+        pass
+
     def remove(
         self,
         record_identifier: Optional[str] = None,

--- a/pipestat/backends/dbbackend.py
+++ b/pipestat/backends/dbbackend.py
@@ -501,6 +501,15 @@ class DBBackend(PipestatBackend):
             }
         raise RecordNotFoundError(f"Record '{record_identifier}' not found")
 
+    def retrieve_multiple(
+        self,
+        record_identifier: Optional[List[str]] = None,
+        result_identifier: Optional[List[str]] = None,
+        limit: Optional[int] = 1000,
+        offset: Optional[int] = 0,
+    ) -> Union[Any, Dict[str, Any]]:
+        pass
+
     def select(
         self,
         columns: Optional[List[str]] = None,

--- a/pipestat/backends/dbbackend.py
+++ b/pipestat/backends/dbbackend.py
@@ -532,11 +532,11 @@ class DBBackend(PipestatBackend):
                     columns=result_identifier, filter_conditions=filter, limit=limit, offset=offset
                 )
                 retrieved_record = {}
-                record_dict = dict(result[0])
-                for k, v in list(record_dict.items()):
+                result_dict = dict(result[0])
+                for k, v in list(result_dict.items()):
                     if k not in self.parsed_schema.results_data.keys():
-                        record_dict.pop(k)
-                retrieved_record.update({r_id: record_dict})
+                        result_dict.pop(k)
+                retrieved_record.update({r_id: result_dict})
                 record_list.append(retrieved_record)
         if record_identifier is None:
             if result_identifier is not None:
@@ -545,14 +545,14 @@ class DBBackend(PipestatBackend):
             records = self.select(
                 columns=result_identifier, filter_conditions=None, limit=limit, offset=offset
             )
-            for i in records:
+            for record in records:
                 retrieved_record = {}
-                record_id = i.record_identifier
-                record_dict = dict(i)
+                r_id = record.record_identifier
+                record_dict = dict(record)
                 for k, v in list(record_dict.items()):
                     if k not in self.parsed_schema.results_data.keys():
                         record_dict.pop(k)
-                retrieved_record.update({record_id: record_dict})
+                retrieved_record.update({r_id: record_dict})
                 record_list.append(retrieved_record)
 
         records_dict = {

--- a/pipestat/backends/dbbackend.py
+++ b/pipestat/backends/dbbackend.py
@@ -508,6 +508,14 @@ class DBBackend(PipestatBackend):
         limit: Optional[int] = 1000,
         offset: Optional[int] = 0,
     ) -> Union[Any, Dict[str, Any]]:
+        """
+        :param List[str] record_identifier: list of record identifiers
+        :param List[str] result_identifier: list of result identifiers to be retrieved
+        :param int limit: limit number of records to this amount
+        :param int offset: offset records by this amount
+        :return Dict[str, any]: a mapping with filtered results reported for the record
+        """
+
         record_list = []
 
         if result_identifier == []:

--- a/pipestat/backends/dbbackend.py
+++ b/pipestat/backends/dbbackend.py
@@ -508,54 +508,51 @@ class DBBackend(PipestatBackend):
         limit: Optional[int] = 1000,
         offset: Optional[int] = 0,
     ) -> Union[Any, Dict[str, Any]]:
+        record_list = []
 
-        columns = result_identifier
+        if result_identifier == []:
+            result_identifier = None
+        if record_identifier == []:
+            record_identifier = None
+
         ORM = self.get_model(table_name=self.table_name)
-        with self.session as s:
 
-            # If nothing is specified, get all the values within a limit.
-            if record_identifier is None and result_identifier is None:
-                record_list = []
-                stmt = sql_select(ORM).offset(offset).limit(limit)
-                records = s.exec(stmt).all()
-                for i in records:
-                    retrieved_record = {}
-                    record_id = i.record_identifier
-                    record_dict = dict(i)
-                    for k,v in record_dict.items():
-                        if k not in self.parsed_schema.results_data.keys():
-                            record_dict.pop(k)
-                    retrieved_record.update({record_id: record_dict})
-                    record_list.append(retrieved_record)
-            else:
-                if columns is not None:
-                    statement = sqlmodel.select(*[getattr(ORM, column) for column in columns])
-                else:
-                    statement = sqlmodel.select(ORM)
-                if isinstance(offset, int):
-                    statement = statement.offset(offset)
-                if isinstance(limit, int):
-                    statement = statement.limit(limit)
-
-                record_list = []
-                for r_id in record_identifier:
-                    statement = statement.where(getattr(ORM, "record_identifier") == r_id)
-                    record = s.exec(statement).all()
-                    for i in record:
-                        retrieved_record = {}
-                        record_id = r_id
-                        record_dict = dict(i)
-                        for k, v in record_dict.items():
-                            if k not in self.parsed_schema.results_data.keys():
-                                record_dict.pop(k)
-                        retrieved_record.update({record_id: record_dict})
-                        record_list.append(retrieved_record)
+        if record_identifier is not None:
+            for r_id in record_identifier:
+                filter = [("record_identifier", "eq", r_id)]
+                result = self.select(
+                    columns=result_identifier, filter_conditions=filter, limit=limit, offset=offset
+                )
+                retrieved_record = {}
+                record_dict = dict(result[0])
+                for k, v in list(record_dict.items()):
+                    if k not in self.parsed_schema.results_data.keys():
+                        record_dict.pop(k)
+                retrieved_record.update({r_id: record_dict})
+                record_list.append(retrieved_record)
+        if record_identifier is None:
+            if result_identifier is not None:
+                result_identifier = ["record_identifier"] + result_identifier
+            record_list = []
+            records = self.select(
+                columns=result_identifier, filter_conditions=None, limit=limit, offset=offset
+            )
+            for i in records:
+                retrieved_record = {}
+                record_id = i.record_identifier
+                record_dict = dict(i)
+                for k, v in list(record_dict.items()):
+                    if k not in self.parsed_schema.results_data.keys():
+                        record_dict.pop(k)
+                retrieved_record.update({record_id: record_dict})
+                record_list.append(retrieved_record)
 
         records_dict = {
             "count": len(record_list),
             "limit": limit,
             "offset": offset,
-            "type": type,
+            "record_identifiers": record_identifier,
+            "result_identifiers": result_identifier,
             "records": record_list,
         }
 

--- a/pipestat/backends/dbbackend.py
+++ b/pipestat/backends/dbbackend.py
@@ -552,7 +552,8 @@ class DBBackend(PipestatBackend):
             "limit": limit,
             "offset": offset,
             "record_identifiers": record_identifier,
-            "result_identifiers": result_identifier,
+            "result_identifiers": result_identifier
+            or list(self.parsed_schema.results_data.keys()) + [CREATED_TIME] + [MODIFIED_TIME],
             "records": record_list,
         }
 

--- a/pipestat/backends/filebackend.py
+++ b/pipestat/backends/filebackend.py
@@ -462,7 +462,42 @@ class FileBackend(PipestatBackend):
         limit: Optional[int] = 1000,
         offset: Optional[int] = 0,
     ) -> Union[Any, Dict[str, Any]]:
-        pass
+        record_list = []
+
+        if result_identifier == []:
+            result_identifier = (
+                list(self.parsed_schema.results_data.keys()) + [CREATED_TIME] + [MODIFIED_TIME]
+            )
+        if record_identifier == [] or record_identifier is None:
+            record_identifier = list(
+                self._data.data[self.pipeline_name][self.pipeline_type].keys()
+            )
+
+        for k in list(self._data.data[self.pipeline_name][self.pipeline_type].keys())[
+            offset : offset + limit
+        ]:
+            if k in record_identifier:
+                retrieved_record = {}
+                retrieved_results = {}
+                for key, value in self._data.data[self.pipeline_name][self.pipeline_type][
+                    k
+                ].items():
+                    if key in result_identifier:
+                        retrieved_results.update({key: value})
+
+                if retrieved_results != {}:
+                    retrieved_record.update({k: retrieved_results})
+                    record_list.append(retrieved_record)
+
+        records_dict = {
+            "count": len(record_list),
+            "limit": limit,
+            "offset": offset,
+            "record_identifiers": record_identifier,
+            "result_identifiers": result_identifier,
+            "records": record_list,
+        }
+        return records_dict
 
     def retrieve(
         self,

--- a/pipestat/backends/filebackend.py
+++ b/pipestat/backends/filebackend.py
@@ -462,6 +462,14 @@ class FileBackend(PipestatBackend):
         limit: Optional[int] = 1000,
         offset: Optional[int] = 0,
     ) -> Union[Any, Dict[str, Any]]:
+        """
+        :param List[str] record_identifier: list of record identifiers
+        :param List[str] result_identifier: list of result identifiers to be retrieved
+        :param int limit: limit number of records to this amount
+        :param int offset: offset records by this amount
+        :return Dict[str, any]: a mapping with filtered results reported for the record
+        """
+
         record_list = []
 
         if result_identifier == []:

--- a/pipestat/backends/filebackend.py
+++ b/pipestat/backends/filebackend.py
@@ -455,6 +455,15 @@ class FileBackend(PipestatBackend):
 
         return results_formatted
 
+    def retrieve_multiple(
+        self,
+        record_identifier: Optional[List[str]] = None,
+        result_identifier: Optional[List[str]] = None,
+        limit: Optional[int] = 1000,
+        offset: Optional[int] = 0,
+    ) -> Union[Any, Dict[str, Any]]:
+        pass
+
     def retrieve(
         self,
         record_identifier: Optional[str] = None,

--- a/pipestat/backends/filebackend.py
+++ b/pipestat/backends/filebackend.py
@@ -472,7 +472,7 @@ class FileBackend(PipestatBackend):
 
         record_list = []
 
-        if result_identifier == []:
+        if result_identifier == [] or result_identifier is None:
             result_identifier = (
                 list(self.parsed_schema.results_data.keys()) + [CREATED_TIME] + [MODIFIED_TIME]
             )

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -515,11 +515,18 @@ class PipestatManager(MutableMapping):
         :return any | Dict[str, any]: a single result or a mapping with all the
             results reported for the record
         """
+        if record_identifier is None and result_identifier is None:
+            return self.backend.retrieve_multiple(
+                record_identifier, result_identifier, limit, offset
+            )
+
         if type(record_identifier) is list or type(result_identifier) is list:
             if len(record_identifier) == 1 and len(result_identifier) == 1:
                 return self.backend.retrieve(record_identifier[0], result_identifier[0])
             else:
-                return self.backend.retrieve_multiple(record_identifier, result_identifier)
+                return self.backend.retrieve_multiple(
+                    record_identifier, result_identifier, limit, offset
+                )
 
         r_id = record_identifier or self.record_identifier
         return self.backend.retrieve(r_id, result_identifier)

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -516,19 +516,23 @@ class PipestatManager(MutableMapping):
             results reported for the record
         """
         if record_identifier is None and result_identifier is None:
+            # This will retrieve all records and columns.
             return self.backend.retrieve_multiple(
                 record_identifier, result_identifier, limit, offset
             )
 
         if type(record_identifier) is list or type(result_identifier) is list:
             if len(record_identifier) == 1 and len(result_identifier) == 1:
+                # If user gives single values, just use retrieve.
                 return self.backend.retrieve(record_identifier[0], result_identifier[0])
             else:
+                # If user gives lists, retrieve_multiple
                 return self.backend.retrieve_multiple(
                     record_identifier, result_identifier, limit, offset
                 )
 
         r_id = record_identifier or self.record_identifier
+
         return self.backend.retrieve(r_id, result_identifier)
 
     @require_backend

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -497,8 +497,8 @@ class PipestatManager(MutableMapping):
     @require_backend
     def retrieve(
         self,
-        record_identifier: Optional[str] = None,
-        result_identifier: Optional[str] = None,
+        record_identifier: Optional[Union[str, List[str]]] = None,
+        result_identifier: Optional[Union[str, List[str]]] = None,
         limit: Optional[int] = 1000,
         offset: Optional[int] = 0,
     ) -> Union[Any, Dict[str, Any]]:
@@ -508,11 +508,11 @@ class PipestatManager(MutableMapping):
         If no result ID specified, results for the entire record will
         be returned.
 
-        :param str record_identifier: name of the sample_level record
-        :param str result_identifier: name of the result to be retrieved
+        :param str | List[str] record_identifier: name of the sample_level record
+        :param str | List[str] result_identifier: name of the result to be retrieved
         :param int limit: limit number of records to this amount
         :param int offset: offset records by this amount
-        :return any | Dict[str, any]: a single result or a mapping with all the
+        :return any | Dict[str, any]: a single result or a mapping with filtered
             results reported for the record
         """
         if record_identifier is None and result_identifier is None:

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -499,6 +499,8 @@ class PipestatManager(MutableMapping):
         self,
         record_identifier: Optional[str] = None,
         result_identifier: Optional[str] = None,
+        limit: Optional[int] = 1000,
+        offset: Optional[int] = 0,
     ) -> Union[Any, Dict[str, Any]]:
         """
         Retrieve a result for a record.
@@ -508,9 +510,16 @@ class PipestatManager(MutableMapping):
 
         :param str record_identifier: name of the sample_level record
         :param str result_identifier: name of the result to be retrieved
+        :param int limit: limit number of records to this amount
+        :param int offset: offset records by this amount
         :return any | Dict[str, any]: a single result or a mapping with all the
             results reported for the record
         """
+        if type(record_identifier) is list or type(result_identifier) is list:
+            if len(record_identifier) == 1 and len(result_identifier) == 1:
+                return self.backend.retrieve(record_identifier[0], result_identifier[0])
+            else:
+                return self.backend.retrieve_multiple(record_identifier, result_identifier)
 
         r_id = record_identifier or self.record_identifier
         return self.backend.retrieve(r_id, result_identifier)

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -394,7 +394,7 @@ class TestRetrieval:
             # Test Retrieve Whole Record
             assert isinstance(psm.retrieve(record_identifier=rec_id), Mapping)
 
-    @pytest.mark.parametrize("backend", ["db"])
+    @pytest.mark.parametrize("backend", ["file", "db"])
     def test_retrieve_multiple(
         self,
         config_file_path,
@@ -445,11 +445,11 @@ class TestRetrieval:
 
             # Test combinations of empty list for either record or result identifiers.
             results = psm.retrieve(record_identifier=r_ids, result_identifier=[])
-            assert results["result_identifiers"] is None
+            assert len(results["result_identifiers"]) == 9
             assert len(results["records"]) == 2
 
             results = psm.retrieve(record_identifier=[], result_identifier=[])
-            assert results["result_identifiers"] is None
+            assert len(results["result_identifiers"]) == 9
             assert len(results["records"]) == 3
 
             results = psm.retrieve(record_identifier=[], result_identifier=res_id)

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -394,7 +394,7 @@ class TestRetrieval:
             # Test Retrieve Whole Record
             assert isinstance(psm.retrieve(record_identifier=rec_id), Mapping)
 
-    @pytest.mark.parametrize("backend", ["file", "db"])
+    @pytest.mark.parametrize("backend", ["db"])
     def test_retrieve_multiple(
         self,
         config_file_path,
@@ -432,9 +432,14 @@ class TestRetrieval:
             results = psm.retrieve(record_identifier=[r_id], result_identifier=[res_id])
             assert results == list(list(values_sample[0].values())[0].values())[0]
 
+            # Use list of results
+            r_ids = ["sample1", "sample2"]
+            res_id = list(list(values_sample[0].values())[0].keys())[0]
+            results = psm.retrieve(record_identifier=r_ids, result_identifier=[res_id])
+
             print("done")
 
-    @pytest.mark.parametrize("backend", ["file", "db"])
+    @pytest.mark.parametrize("backend", ["db"])
     def test_get_records(
         self,
         config_file_path,

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -403,12 +403,12 @@ class TestRetrieval:
         backend,
     ):
         values_sample = [
-            {"sample1": {"name_of_something": "name_of_something string"}},
+            {"sample1": {"name_of_something": "string 1"}},
             {"sample1": {"number_of_things": 1}},
-            {"sample2": {"name_of_something": "name_of_something string"}},
-            {"sample2": {"number_of_things": 1}},
-            {"sample3": {"name_of_something": "name_of_something string"}},
-            {"sample3": {"number_of_things": 1}},
+            {"sample2": {"name_of_something": "string 2"}},
+            {"sample2": {"number_of_things": 20}},
+            {"sample3": {"name_of_something": "string 3"}},
+            {"sample3": {"number_of_things": 300}},
         ]
 
         with NamedTemporaryFile() as f, ContextManagerDBTesting(DB_URL):
@@ -434,10 +434,27 @@ class TestRetrieval:
 
             # Use list of results
             r_ids = ["sample1", "sample2"]
-            res_id = list(list(values_sample[0].values())[0].keys())[0]
-            results = psm.retrieve(record_identifier=r_ids, result_identifier=[res_id])
+            res_id = ["md5sum", "number_of_things"]
+            # res_id = list(list(values_sample[0].values())[0].keys())[0]
+            results = psm.retrieve(record_identifier=r_ids, result_identifier=res_id)
+            assert r_ids[0] == list(results["records"][0].keys())[0]
+            assert (
+                list(list(values_sample[3].values())[0].values())[0]
+                == list(results["records"][1].values())[0]["number_of_things"]
+            )
 
-            print("done")
+            # Test combinations of empty list for either record or result identifiers.
+            results = psm.retrieve(record_identifier=r_ids, result_identifier=[])
+            assert results["result_identifiers"] is None
+            assert len(results["records"]) == 2
+
+            results = psm.retrieve(record_identifier=[], result_identifier=[])
+            assert results["result_identifiers"] is None
+            assert len(results["records"]) == 3
+
+            results = psm.retrieve(record_identifier=[], result_identifier=res_id)
+            assert "md5sum" in results["result_identifiers"]
+            assert len(results["records"]) == 3
 
     @pytest.mark.parametrize("backend", ["db"])
     def test_get_records(


### PR DESCRIPTION
Add retrieve_multiple to backends, allow retrieve to use a list of record_identifiers and/or a list of result_identifiers