### PR TITLE
Dev 99 103 api refactor

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.6.0] - 2023-10-XX
 ### Added
-
+- Add select_records, which allows for a single API for selecting attributes (result_identifiers)
+- Add retrieve_one, and retrieve_many which allows for selecting one or multiple records given record_identifier
 - Add pipestat reader submodule to read DB results via FastAPI endpoints: `pipestat serve --config "config.yaml"`
 - Add ability to create `SamplePipestatManager` and `ProjectSamplePipestatManager` which are sample/project specific PipestatManager objects.
 - Add PipestatBoss wrapper class which holds `SamplePipestatManager` and `ProjectSamplePipestatManager` classes.

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -224,5 +224,6 @@ def select_records(
     json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
     limit: Optional[int] = 1000,
     cursor: Optional[int] = None,
+
 ) -> List[Any]:
     _LOGGER.warning("Not implemented yet for this backend")

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -199,6 +199,7 @@ def select_records(
 ) -> Dict[str, Any]:
     _LOGGER.warning("Not implemented yet for this backend")
 
+
 def select_distinct(
     self,
     columns,

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -105,8 +105,8 @@ class PipestatBackend(ABC):
         all_records = self.select_records()
 
         for record in all_records["records"]:
-            result_identifiers = self.retrieve(record_identifier=record["record_identifier"])
-            for k, v in result_identifiers.items():
+            # result_identifiers = record.keys() #self.select_records(record_identifier=record["record_identifier"])
+            for k, v in record.items():
                 if type(v) == dict:
                     all_paths = get_all_paths(k, v)
                     for path in all_paths:

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -152,7 +152,6 @@ class PipestatBackend(ABC):
         _LOGGER.warning("Not implemented yet for this backend")
         pass
 
-
     def report(
         self,
         values: Dict[str, Any],
@@ -174,7 +173,6 @@ class PipestatBackend(ABC):
     ) -> Union[Any, Dict[str, Any]]:
         _LOGGER.warning("Not implemented yet for this backend")
         pass
-
 
     def remove(
         self,

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -220,10 +220,9 @@ class PipestatBackend(ABC):
 def select_records(
     self,
     columns: Optional[List[str]] = None,
-    filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
-    json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
+    filter_conditions: Optional[List[Dict[str, Any]]] = None,
     limit: Optional[int] = 1000,
     cursor: Optional[int] = None,
     bool_operator: Optional[str] = "AND",
-) -> List[Any]:
+) -> Dict[str, Any]:
     _LOGGER.warning("Not implemented yet for this backend")

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -162,12 +162,6 @@ class PipestatBackend(ABC):
         _LOGGER.warning("Not implemented yet for this backend")
         pass
 
-    def retrieve(
-        self, record_identifier: Optional[str] = None, result_identifier: Optional[str] = None
-    ) -> Union[Any, Dict[str, Any]]:
-        _LOGGER.warning("Not implemented yet for this backend")
-        pass
-
     def remove(
         self,
         record_identifier: Optional[str] = None,

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -222,7 +222,7 @@ def select_records(
     columns: Optional[List[str]] = None,
     filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
     json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
-    offset: Optional[int] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 1000,
+    cursor: Optional[int] = None,
 ) -> List[Any]:
     _LOGGER.warning("Not implemented yet for this backend")

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -152,15 +152,6 @@ class PipestatBackend(ABC):
         _LOGGER.warning("Not implemented yet for this backend")
         pass
 
-    def list_recent_results(
-        self,
-        limit: Optional[int] = None,
-        start: Optional[datetime.datetime] = None,
-        end: Optional[datetime.datetime] = None,
-        type: Optional[str] = None,
-    ) -> List[str]:
-        _LOGGER.warning("Not implemented yet for this backend")
-        pass
 
     def report(
         self,
@@ -184,23 +175,6 @@ class PipestatBackend(ABC):
         _LOGGER.warning("Not implemented yet for this backend")
         pass
 
-    def retrieve_multiple(
-        self,
-        record_identifier: Optional[List[str]] = None,
-        result_identifier: Optional[List[str]] = None,
-        limit: Optional[int] = 1000,
-        offset: Optional[int] = 0,
-    ) -> Union[Any, Dict[str, Any]]:
-        """
-        :param List[str] record_identifier: list of record identifiers
-        :param List[str] result_identifier: list of result identifiers to be retrieved
-        :param int limit: limit number of records to this amount
-        :param int offset: offset records by this amount
-        :return Dict[str, any]: a mapping with filtered results reported for the record
-        """
-
-        _LOGGER.warning("Not implemented yet for this backend")
-        pass
 
     def remove(
         self,

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -224,6 +224,6 @@ def select_records(
     json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
     limit: Optional[int] = 1000,
     cursor: Optional[int] = None,
-
+    bool_operator: Optional[str] = "AND",
 ) -> List[Any]:
     _LOGGER.warning("Not implemented yet for this backend")

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -215,3 +215,14 @@ class PipestatBackend(ABC):
         rm_record: Optional[bool] = False,
     ) -> bool:
         _LOGGER.warning("Not implemented yet for this backend")
+
+
+def select_records(
+    self,
+    columns: Optional[List[str]] = None,
+    filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
+    json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
+    offset: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> List[Any]:
+    _LOGGER.warning("Not implemented yet for this backend")

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -78,14 +78,6 @@ class PipestatBackend(ABC):
         _LOGGER.warning("Not implemented yet for this backend")
         pass
 
-    def get_records(
-        self,
-        limit: Optional[int] = 1000,
-        offset: Optional[int] = 0,
-    ) -> Optional[dict]:
-        _LOGGER.warning("Not implemented yet for this backend")
-        pass
-
     def get_status(self, record_identifier: str) -> Optional[str]:
         _LOGGER.warning("Not implemented yet for this backend")
 
@@ -110,10 +102,10 @@ class PipestatBackend(ABC):
 
         unique_result_identifiers = []
 
-        all_records = self.get_records()
+        all_records = self.select_records()
 
         for record in all_records["records"]:
-            result_identifiers = self.retrieve(record_identifier=record)
+            result_identifiers = self.retrieve(record_identifier=record["record_identifier"])
             for k, v in result_identifiers.items():
                 if type(v) == dict:
                     all_paths = get_all_paths(k, v)
@@ -129,7 +121,9 @@ class PipestatBackend(ABC):
                         for subdir in unique_result_identifiers:
                             if k == subdir[0]:
                                 target_dir = subdir[1]
-                        linkname = os.path.join(target_dir, record + "_" + path[0] + "_" + file)
+                        linkname = os.path.join(
+                            target_dir, record["record_identifier"] + "_" + path[0] + "_" + file
+                        )
                         src = os.path.abspath(path[1])
                         src_rel = os.path.relpath(src, os.path.dirname(linkname))
                         force_symlink(src_rel, linkname)

--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -198,3 +198,9 @@ def select_records(
     bool_operator: Optional[str] = "AND",
 ) -> Dict[str, Any]:
     _LOGGER.warning("Not implemented yet for this backend")
+
+def select_distinct(
+    self,
+    columns,
+) -> List[Tuple]:
+    _LOGGER.warning("Not implemented yet for this backend")

--- a/pipestat/backends/db_backend/db_helpers.py
+++ b/pipestat/backends/db_backend/db_helpers.py
@@ -122,7 +122,7 @@ def selection_filter(
         return tuple(x)
 
     if filter_conditions is not None:
-        for filter_condition in filter_conditions:
+        for filter_condition in filter_conditions: # These are ANDs
             key, op, value = _unpack_tripartite(filter_condition)
             column = getattr(ORM, key, None)
             if column is None:
@@ -142,10 +142,12 @@ def selection_filter(
             statement = statement.where(filt)
 
     if json_filter_conditions is not None:
-        for json_filter_condition in json_filter_conditions:
+        for json_filter_condition in json_filter_conditions: #These are ANDs
             col, key, value = _unpack_tripartite(json_filter_condition)
             column = getattr(ORM, col)
             #statement = statement.where(getattr(ORM, col) == value)
+
+            # This needs error handling so that the user understands when they give it a string that cannot be converted
             value = json.loads(value)
             statement = statement.where(column.contains(value))
             print(statement)

--- a/pipestat/backends/db_backend/db_helpers.py
+++ b/pipestat/backends/db_backend/db_helpers.py
@@ -1,14 +1,13 @@
 # DB Sepcific imports
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote_plus
-import json
 
 try:
     import sqlalchemy.orm
     import sqlmodel.sql.expression
     from sqlmodel.main import SQLModel
     from sqlmodel.sql.expression import SelectOfScalar
-    from sqlmodel import and_, or_
+    from sqlmodel import and_, or_, Integer, Float, String, Boolean
 except:
     pass
 
@@ -91,11 +90,11 @@ def dynamic_filter(
 
     return statement
 
+
 def selection_filter(
     ORM: Any,
     statement: Any,
-    filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
-    json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
+    filter_conditions: Optional[List[Dict[str, Union[str, List[str]]]]] = None,
     bool_operator: Optional[str] = "AND",
 ) -> Any:
     """
@@ -103,15 +102,14 @@ def selection_filter(
 
     :param sqlalchemy.orm.DeclarativeMeta ORM:
     :param sqlalchemy.orm.Query query: takes query
-    :param [(key,operator,value)] filter_conditions: e.g. [("id", "eq", 1)] operator list
+    :param [{key: key,
+            operator: operator,
+            value: value}]
+    filter_conditions:
         - eq for ==
         - lt for <
         - ge for >=
         - in for in_
-        - like for like -> get rid of this one!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-    :param [(col,key,value)] json_filter_conditions: conditions for JSONB column to query.
-        Only '==' is supported e.g. [("other", "genome", "hg38")]
     :return: query
     """
 
@@ -123,23 +121,55 @@ def selection_filter(
         # Create warning here
         sqlmodel_operator = and_
 
+    def get_nested_column(ORM_column, key_list):
+        if len(key_list) == 1:
+            return ORM_column[key_list[0]]
+        else:
+            return get_nested_column(ORM_column[key_list[0]], key_list[1:])
 
-    def _unpack_tripartite(x):
-        if not (isinstance(x, List) or isinstance(x, Tuple)):
-            raise TypeError("Wrong filter class; a List or Tuple is required")
-        if len(x) != 3:
-            raise ValueError(
-                f"Invalid filter value: {x}. The filter must be a tripartite iterable"
-            )
-        return tuple(x)
+    def define_sqlalchemy_type(value: Any):
+        if isinstance(value, Union[list, tuple]):
+            value = value[0]
+        if isinstance(value, int):
+            return Integer
+        elif isinstance(value, float):
+            return Float
+        elif isinstance(value, str):
+            return String
+        elif isinstance(value, bool):
+            return Boolean
+        else:
+            raise ValueError(f"Value type {type(value)} not supported")
 
     if filter_conditions is not None:
         filter_list = []
-        for filter_condition in filter_conditions: # These are ANDs
-            key, op, value = _unpack_tripartite(filter_condition)
-            column = getattr(ORM, key, None)
+        for filter_condition in filter_conditions:
+            if list(filter_condition.keys()) != ["key", "operator", "value"]:
+                raise ValueError(
+                    "Filter conditions must be a dictionary with keys 'key', 'operator', and 'value'"
+                )
+
+            if isinstance(filter_condition["key"], list):
+                if len(filter_condition["key"]) == 1:
+                    column = getattr(ORM, filter_condition["key"][0], None)
+                else:
+                    column = get_nested_column(
+                        getattr(ORM, filter_condition["key"][0], None), filter_condition["key"][1:]
+                    ).astext.cast(define_sqlalchemy_type(filter_condition["value"]))
+
+            elif isinstance(filter_condition["key"], str):
+                column = getattr(ORM, filter_condition["key"], None)
+
+            else:
+                raise ValueError("Filter condition key must be a string or list of strings")
+
+            op = filter_condition["operator"]
+            value = filter_condition["value"]
+
             if column is None:
-                raise ValueError(f"Selected filter column does not exist: {key}")
+                raise ValueError(
+                    f"Selected filter column does not exist: {filter_condition['key']}"
+                )
             if op == "in":
                 filt = column.in_(value if isinstance(value, list) else value.split(","))
             else:
@@ -155,16 +185,5 @@ def selection_filter(
             filter_list.append(filt)
 
         statement = statement.where(sqlmodel_operator(*filter_list))
-
-    if json_filter_conditions is not None:
-        for json_filter_condition in json_filter_conditions: #These are ANDs
-            col, key, value = _unpack_tripartite(json_filter_condition)
-            column = getattr(ORM, col)
-            #statement = statement.where(getattr(ORM, col) == value)
-
-            # This needs error handling so that the user understands when they give it a string that cannot be converted
-            value = json.loads(value)
-            statement = statement.where(column.contains(value))
-            print(statement)
 
     return statement

--- a/pipestat/backends/db_backend/db_helpers.py
+++ b/pipestat/backends/db_backend/db_helpers.py
@@ -32,65 +32,6 @@ def construct_db_url(dbconf):
     return "{dialect}+{driver}://{user}:{passwd}@{host}:{port}/{name}".format(**parsed_creds)
 
 
-def dynamic_filter(
-    ORM: Any,
-    statement: Any,
-    filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
-    json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
-) -> Any:
-    """
-    Return filtered query based on condition.
-
-    :param sqlalchemy.orm.DeclarativeMeta ORM: sqlalchemy ORM object
-    :param sqlalchemy.orm.Query statement: sqlalchemy select statement (e.g. select([ORM])
-    :param [(key,operator,value)] filter_conditions: e.g. [("id", "eq", 1)] operator list
-        - eq for ==
-        - lt for <
-        - ge for >=
-        - in for in_
-        - like for like
-    :param [(col,key,value)] json_filter_conditions: conditions for JSONB column to query.
-        Only '==' is supported e.g. [("other", "genome", "hg38")]
-    :return: query
-    """
-
-    def _unpack_tripartite(x):
-        if not (isinstance(x, List) or isinstance(x, Tuple)):
-            raise TypeError("Wrong filter class; a List or Tuple is required")
-        if len(x) != 3:
-            raise ValueError(
-                f"Invalid filter value: {x}. The filter must be a tripartite iterable"
-            )
-        return tuple(x)
-
-    if filter_conditions is not None:
-        for filter_condition in filter_conditions:
-            key, op, value = _unpack_tripartite(filter_condition)
-            column = getattr(ORM, key, None)
-            if column is None:
-                raise ValueError(f"Selected filter column does not exist: {key}")
-            if op == "in":
-                filt = column.in_(value if isinstance(value, list) else value.split(","))
-            else:
-                attr = next(
-                    filter(lambda a: hasattr(column, a), [op, op + "_", f"__{op}__"]),
-                    None,
-                )
-                if attr is None:
-                    raise ValueError(f"Invalid filter operator: {op}")
-                if value == "null":
-                    value = None
-                filt = getattr(column, attr)(value)
-            statement = statement.where(filt)
-
-    if json_filter_conditions is not None:
-        for json_filter_condition in json_filter_conditions:
-            col, key, value = _unpack_tripartite(json_filter_condition)
-            statement = statement.where(getattr(ORM, col) == value)
-
-    return statement
-
-
 def selection_filter(
     ORM: Any,
     statement: Any,

--- a/pipestat/backends/db_backend/db_helpers.py
+++ b/pipestat/backends/db_backend/db_helpers.py
@@ -1,6 +1,7 @@
 # DB Sepcific imports
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote_plus
+import json
 
 try:
     import sqlalchemy.orm
@@ -86,5 +87,67 @@ def dynamic_filter(
         for json_filter_condition in json_filter_conditions:
             col, key, value = _unpack_tripartite(json_filter_condition)
             statement = statement.where(getattr(ORM, col) == value)
+
+    return statement
+
+def selection_filter(
+    ORM: Any,
+    statement: Any,
+    filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
+    json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
+) -> Any:
+    """
+    Return filtered query based on condition.
+
+    :param sqlalchemy.orm.DeclarativeMeta ORM:
+    :param sqlalchemy.orm.Query query: takes query
+    :param [(key,operator,value)] filter_conditions: e.g. [("id", "eq", 1)] operator list
+        - eq for ==
+        - lt for <
+        - ge for >=
+        - in for in_
+        - like for like
+    :param [(col,key,value)] json_filter_conditions: conditions for JSONB column to query.
+        Only '==' is supported e.g. [("other", "genome", "hg38")]
+    :return: query
+    """
+
+    def _unpack_tripartite(x):
+        if not (isinstance(x, List) or isinstance(x, Tuple)):
+            raise TypeError("Wrong filter class; a List or Tuple is required")
+        if len(x) != 3:
+            raise ValueError(
+                f"Invalid filter value: {x}. The filter must be a tripartite iterable"
+            )
+        return tuple(x)
+
+    if filter_conditions is not None:
+        for filter_condition in filter_conditions:
+            key, op, value = _unpack_tripartite(filter_condition)
+            column = getattr(ORM, key, None)
+            if column is None:
+                raise ValueError(f"Selected filter column does not exist: {key}")
+            if op == "in":
+                filt = column.in_(value if isinstance(value, list) else value.split(","))
+            else:
+                attr = next(
+                    filter(lambda a: hasattr(column, a), [op, op + "_", f"__{op}__"]),
+                    None,
+                )
+                if attr is None:
+                    raise ValueError(f"Invalid filter operator: {op}")
+                if value == "null":
+                    value = None
+                filt = getattr(column, attr)(value)
+            statement = statement.where(filt)
+
+    if json_filter_conditions is not None:
+        for json_filter_condition in json_filter_conditions:
+            col, key, value = _unpack_tripartite(json_filter_condition)
+            column = getattr(ORM, col)
+            #statement = statement.where(getattr(ORM, col) == value)
+            value = json.loads(value)
+            statement = statement.where(column.contains(value))
+            print(statement)
 
     return statement

--- a/pipestat/backends/db_backend/db_helpers.py
+++ b/pipestat/backends/db_backend/db_helpers.py
@@ -124,26 +124,6 @@ def selection_filter(
         # Create warning here
         sqlmodel_operator = and_
 
-    def get_nested_column(ORM_column, key_list):
-        if len(key_list) == 1:
-            return ORM_column[key_list[0]]
-        else:
-            return get_nested_column(ORM_column[key_list[0]], key_list[1:])
-
-    def define_sqlalchemy_type(value: Any):
-        if isinstance(value, (list, tuple)):
-            value = value[0]
-        if isinstance(value, int):
-            return Integer
-        elif isinstance(value, float):
-            return Float
-        elif isinstance(value, str):
-            return String
-        elif isinstance(value, bool):
-            return Boolean
-        else:
-            raise ValueError(f"Value type {type(value)} not supported")
-
     if filter_conditions is not None:
         filter_list = []
         for filter_condition in filter_conditions:
@@ -190,3 +170,25 @@ def selection_filter(
         statement = statement.where(sqlmodel_operator(*filter_list))
 
     return statement
+
+
+def get_nested_column(ORM_column, key_list):
+    if len(key_list) == 1:
+        return ORM_column[key_list[0]]
+    else:
+        return get_nested_column(ORM_column[key_list[0]], key_list[1:])
+
+
+def define_sqlalchemy_type(value: Any):
+    if isinstance(value, (list, tuple)):
+        value = value[0]
+    if isinstance(value, int):
+        return Integer
+    elif isinstance(value, float):
+        return Float
+    elif isinstance(value, str):
+        return String
+    elif isinstance(value, bool):
+        return Boolean
+    else:
+        raise ValueError(f"Value type {type(value)} not supported")

--- a/pipestat/backends/db_backend/db_helpers.py
+++ b/pipestat/backends/db_backend/db_helpers.py
@@ -111,7 +111,7 @@ def selection_filter(
         - lt for <
         - ge for >=
         - in for in_
-    :param bool bool_operator
+    :param bool bool_operator:
 
     :return: query statement
     """
@@ -173,6 +173,11 @@ def selection_filter(
 
 
 def get_nested_column(ORM_column, key_list):
+    """
+    :param sqlalchemy.orm.DeclarativeMeta ORM_column: column attribute on the current ORM
+    :param key_list: list of keys, e.g. if the column contains a complex object
+    :return sqlalchemy.orm.DeclarativeMeta ORM: column attribute of ORM.
+    """
     if len(key_list) == 1:
         return ORM_column[key_list[0]]
     else:
@@ -180,6 +185,7 @@ def get_nested_column(ORM_column, key_list):
 
 
 def define_sqlalchemy_type(value: Any):
+    """Determines the data type of input value"""
     if isinstance(value, (list, tuple)):
         value = value[0]
     if isinstance(value, int):

--- a/pipestat/backends/db_backend/db_helpers.py
+++ b/pipestat/backends/db_backend/db_helpers.py
@@ -1,5 +1,5 @@
 # DB Sepcific imports
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import quote_plus
 
 try:

--- a/pipestat/backends/db_backend/db_helpers.py
+++ b/pipestat/backends/db_backend/db_helpers.py
@@ -131,7 +131,7 @@ def selection_filter(
             return get_nested_column(ORM_column[key_list[0]], key_list[1:])
 
     def define_sqlalchemy_type(value: Any):
-        if isinstance(value, Union[list, tuple]):
+        if isinstance(value, (list, tuple)):
             value = value[0]
         if isinstance(value, int):
             return Integer

--- a/pipestat/backends/db_backend/db_helpers.py
+++ b/pipestat/backends/db_backend/db_helpers.py
@@ -108,7 +108,8 @@ def selection_filter(
         - lt for <
         - ge for >=
         - in for in_
-        - like for like
+        - like for like -> get rid of this one!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
     :param [(col,key,value)] json_filter_conditions: conditions for JSONB column to query.
         Only '==' is supported e.g. [("other", "genome", "hg38")]
     :return: query

--- a/pipestat/backends/db_backend/db_helpers.py
+++ b/pipestat/backends/db_backend/db_helpers.py
@@ -101,8 +101,9 @@ def selection_filter(
     Return filtered query based on condition.
 
     :param sqlalchemy.orm.DeclarativeMeta ORM:
-    :param sqlalchemy.orm.Query query: takes query
-    :param [{key: key,
+    :param sqlalchemy.orm.Query statement: sql.alchemy query
+    :param list filter_conditions
+            [{key: key,
             operator: operator,
             value: value}]
     filter_conditions:
@@ -110,7 +111,9 @@ def selection_filter(
         - lt for <
         - ge for >=
         - in for in_
-    :return: query
+    :param bool bool_operator
+
+    :return: query statement
     """
 
     if bool_operator.lower() == "or":

--- a/pipestat/backends/db_backend/db_helpers.py
+++ b/pipestat/backends/db_backend/db_helpers.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote_plus
 
 try:
-    import sqlalchemy.orm
+    from sqlmodel import MetaData
     import sqlmodel.sql.expression
     from sqlmodel.main import SQLModel
     from sqlmodel.sql.expression import SelectOfScalar
@@ -41,8 +41,8 @@ def dynamic_filter(
     """
     Return filtered query based on condition.
 
-    :param sqlalchemy.orm.DeclarativeMeta ORM:
-    :param sqlalchemy.orm.Query query: takes query
+    :param sqlalchemy.orm.DeclarativeMeta ORM: sqlalchemy ORM object
+    :param sqlalchemy.orm.Query statement: sqlalchemy select statement (e.g. select([ORM])
     :param [(key,operator,value)] filter_conditions: e.g. [("id", "eq", 1)] operator list
         - eq for ==
         - lt for <
@@ -100,9 +100,9 @@ def selection_filter(
     """
     Return filtered query based on condition.
 
-    :param sqlalchemy.orm.DeclarativeMeta ORM:
-    :param sqlalchemy.orm.Query statement: sql.alchemy query
-    :param list filter_conditions
+    :param sqlalchemy.orm.DeclarativeMeta ORM: sqlalchemy ORM object
+    :param sqlalchemy.orm.Query statement: sqlalchemy select statement (e.g. select([ORM])
+    :param list filter_conditions:
             [{key: key,
             operator: operator,
             value: value}]
@@ -174,6 +174,8 @@ def selection_filter(
 
 def get_nested_column(ORM_column, key_list):
     """
+    Create statement for nested column in the database, column with json content inside
+
     :param sqlalchemy.orm.DeclarativeMeta ORM_column: column attribute on the current ORM
     :param key_list: list of keys, e.g. if the column contains a complex object
     :return sqlalchemy.orm.DeclarativeMeta ORM: column attribute of ORM.
@@ -184,8 +186,13 @@ def get_nested_column(ORM_column, key_list):
         return get_nested_column(ORM_column[key_list[0]], key_list[1:])
 
 
-def define_sqlalchemy_type(value: Any):
-    """Determines the data type of input value"""
+def define_sqlalchemy_type(value: Any) -> Any:
+    """
+    Determine the type of the column (record) and return the corresponding sqlalchemy type.
+
+    :param value: value of the column
+    :return: sqlalchemy type
+    """
     if isinstance(value, (list, tuple)):
         value = value[0]
     if isinstance(value, int):

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -634,7 +634,7 @@ class DBBackend(PipestatBackend):
         Perform a `SELECT` on the table
 
         :param list[str] columns: columns to include in the result
-        :param list[tuple(str,str,str)] [(key,operator,value)] filter_conditions: e.g. [("id", "eq", 1)], operator list:
+        :param list[dict]  filter_conditions: e.g. [{"key": ["id"], "operator": "eq", "value": 1)], operator list:
             - eq for ==
             - lt for <
             - ge for >=

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -574,55 +574,6 @@ class DBBackend(PipestatBackend):
 
         return records_dict
 
-    def select(
-        self,
-        columns: Optional[List[str]] = None,
-        filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
-        json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-    ) -> List[Any]:
-        """
-        Perform a `SELECT` on the table
-
-        :param List[str] columns: columns to include in the result
-        :param [(key,operator,value)] filter_conditions: e.g. [("id", "eq", 1)], operator list:
-            - eq for ==
-            - lt for <
-            - ge for >=
-            - in for in_
-            - like for like
-        :param [(col,key,value)] json_filter_conditions: conditions for JSONB column to
-            query that include JSON column name, key withing the JSON object in that
-            column and the value to check the identity against. Therefore only '==' is
-            supported in non-nested checks, e.g. [("other", "genome", "hg38")]
-        :param int offset: skip this number of rows
-        :param int limit: include this number of rows
-        """
-
-        ORM = self.get_model(table_name=self.table_name)
-
-        with self.session as s:
-            if columns is not None:
-                statement = sqlmodel.select(*[getattr(ORM, column) for column in columns])
-            else:
-                statement = sqlmodel.select(ORM)
-
-            statement = dynamic_filter(
-                ORM=ORM,
-                statement=statement,
-                filter_conditions=filter_conditions,
-                json_filter_conditions=json_filter_conditions,
-            )
-            if isinstance(offset, int):
-                statement = statement.offset(offset)
-            if isinstance(limit, int):
-                statement = statement.limit(limit)
-            results = s.exec(statement)
-            result = results.all()
-
-        return result
-
     def select_records(
         self,
         columns: Optional[List[str]] = None,

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -201,7 +201,7 @@ class DBBackend(PipestatBackend):
         """
         Remove a result.
 
-        If no result ID specified or last result is removed, the entire record
+        If no result ID specified, the entire record
         will be removed.
 
         :param str record_identifier: unique identifier of the record
@@ -210,6 +210,7 @@ class DBBackend(PipestatBackend):
         :return bool: whether the result has been removed
         """
 
+        # TODO removing last result identifier (apart from created, modified time should remove record)
         record_identifier = record_identifier or self.record_identifier
         rm_record = True if result_identifier is None else False
 
@@ -404,9 +405,14 @@ class DBBackend(PipestatBackend):
 
             if columns is not None:
                 columns = ["id", "record_identifier"] + columns  # Must add id, need it for cursor
-                statement = sqlmodel.select(
-                    *[getattr(ORM, column) for column in columns]
-                ).order_by(ORM.id)
+                try:
+                    statement = sqlmodel.select(
+                        *[getattr(ORM, column) for column in columns]
+                    ).order_by(ORM.id)
+                except AttributeError:
+                    raise ColumnNotFoundError(
+                        msg=f"One of the supplied column does not exists in current table: {columns}"
+                    )
             else:
                 statement = sqlmodel.select(ORM).order_by(ORM.id)
 

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -626,7 +626,6 @@ class DBBackend(PipestatBackend):
         self,
         columns: Optional[List[str]] = None,
         filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
-        json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
         limit: Optional[int] = 1000,
         cursor: Optional[int] = None,
         bool_operator: Optional[str] = "AND",
@@ -669,7 +668,6 @@ class DBBackend(PipestatBackend):
                 ORM=ORM,
                 statement=statement,
                 filter_conditions=filter_conditions,
-                json_filter_conditions=json_filter_conditions,
                 bool_operator=bool_operator,
             )
 

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -51,7 +51,6 @@ class DBBackend(PipestatBackend):
         :param str result_formatter: function for formatting result
         """
 
-
         super().__init__(pipeline_type)
         _LOGGER.warning(f"Initializing DBBackend for pipeline '{pipeline_name}'")
         self.pipeline_name = pipeline_name

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -625,7 +625,7 @@ class DBBackend(PipestatBackend):
     def select_records(
         self,
         columns: Optional[List[str]] = None,
-        filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
+        filter_conditions: Optional[List[Dict[str, Any]]] = None,
         limit: Optional[int] = 1000,
         cursor: Optional[int] = None,
         bool_operator: Optional[str] = "AND",

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -664,7 +664,7 @@ class DBBackend(PipestatBackend):
             if cursor is not None:
                 statement = statement.where(ORM.id > cursor)
 
-            statement = dynamic_filter(
+            statement = selection_filter(
                 ORM=ORM,
                 statement=statement,
                 filter_conditions=filter_conditions,

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -132,10 +132,6 @@ class DBBackend(PipestatBackend):
         """
 
         try:
-            result = self.retrieve(
-                record_identifier=record_identifier,
-                result_identifier=STATUS,
-            )
             result = self.select_records(
                 columns=[STATUS],
                 filter_conditions=[
@@ -148,7 +144,12 @@ class DBBackend(PipestatBackend):
             )
         except RecordNotFoundError:
             return None
-        return result
+        try:
+            status = result["records"][0]["status"]
+        except IndexError:
+            status = None
+
+        return status
 
     def list_results(
         self,

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -525,14 +525,16 @@ class DBBackend(PipestatBackend):
 
     def select_distinct(
         self,
-        columns,
+        columns: Union[str, List[str]],
     ) -> List[Tuple]:
         """
         Perform a `SELECT DISTINCT` on given table and column
 
-        :param List[str] columns: columns to include in the result
+        :param str | List[str] columns: columns to include in the result
         :return List[Tuple]: returns distinct values.
         """
+        if isinstance(columns, str):
+            columns = [columns]
 
         ORM = self.get_model(table_name=self.table_name)
         with self.session as s:

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -629,6 +629,7 @@ class DBBackend(PipestatBackend):
         json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
         limit: Optional[int] = 1000,
         cursor: Optional[int] = None,
+        bool_operator: Optional[str] = "AND",
     ) -> List[Any]:
         """
         Perform a `SELECT` on the table
@@ -669,6 +670,7 @@ class DBBackend(PipestatBackend):
                 statement=statement,
                 filter_conditions=filter_conditions,
                 json_filter_conditions=json_filter_conditions,
+                bool_operator=bool_operator,
             )
 
             if isinstance(limit, int):

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -640,65 +640,6 @@ class DBBackend(PipestatBackend):
 
         return records_dict
 
-    def select_txt(
-        self,
-        columns: Optional[List[str]] = None,
-        filter_templ: Optional[str] = "",
-        filter_params: Optional[Dict[str, Any]] = {},
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-    ) -> List[Any]:
-        """
-        Execute a query with a textual filter. Returns all results.
-
-        To retrieve all table contents, leave the filter arguments out.
-        Table name uses pipeline_type
-
-        :param List[str] columns: columns to include in the result
-        :param str filter_templ: filter template with value placeholders,
-             formatted as follows `id<:value and name=:name`
-        :param Dict[str, Any] filter_params: a mapping keys specified in the `filter_templ`
-            to parameters that are supposed to replace the placeholders
-        :param int offset: skip this number of rows
-        :param int limit: include this number of rows
-        :return List[Any]: a list of matched records
-        """
-
-        ORM = self.get_model(table_name=self.table_name)
-        with self.session as s:
-            if columns is not None:
-                q = (
-                    s.query(*[getattr(ORM, column) for column in columns])
-                    .filter(text(filter_templ))
-                    .params(**filter_params)
-                )
-            else:
-                q = s.query(ORM).filter(text(filter_templ)).params(**filter_params)
-            if isinstance(offset, int):
-                q = q.offset(offset)
-            if isinstance(limit, int):
-                q = q.limit(limit)
-            results = q.all()
-        return results
-
-    def select_distinct(
-        self,
-        columns,
-    ) -> List[Tuple]:
-        """
-        Perform a `SELECT DISTINCT` on given table and column
-
-        :param List[str] columns: columns to include in the result
-        :return List[Tuple]: returns distinct values.
-        """
-
-        ORM = self.get_model(table_name=self.table_name)
-        with self.session as s:
-            query = s.query(*[getattr(ORM, column) for column in columns])
-            query = query.distinct()
-            result = query.all()
-        return result
-
     def set_status(
         self,
         status_identifier: str,

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -172,7 +172,18 @@ class DBBackend(PipestatBackend):
         """
 
         rid = record_identifier
-        record = self.get_one_record(rid=rid, table_name=self.table_name)
+        #record = self.get_one_record(rid=rid, table_name=self.table_name)
+        record = self.select_records(filter_conditions=[
+                    {
+                        "key": "record_identifier",
+                        "operator": "eq",
+                        "value": rid,
+                    }])
+        try:
+            record = record["records"][0]
+        except IndexError:
+            return []
+
 
         if restrict_to is None:
             return (

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -457,7 +457,6 @@ class DBBackend(PipestatBackend):
             }
         raise RecordNotFoundError(f"Record '{record_identifier}' not found")
 
-
     def select_records(
         self,
         columns: Optional[List[str]] = None,

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -622,6 +622,55 @@ class DBBackend(PipestatBackend):
 
         return result
 
+    def select_records(
+        self,
+        columns: Optional[List[str]] = None,
+        filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
+        json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> List[Any]:
+        """
+        Perform a `SELECT` on the table
+
+        :param List[str] columns: columns to include in the result
+        :param [(key,operator,value)] filter_conditions: e.g. [("id", "eq", 1)], operator list:
+            - eq for ==
+            - lt for <
+            - ge for >=
+            - in for in_
+            - like for like
+        :param [(col,key,value)] json_filter_conditions: conditions for JSONB column to
+            query that include JSON column name, key withing the JSON object in that
+            column and the value to check the identity against. Therefore only '==' is
+            supported in non-nested checks, e.g. [("other", "genome", "hg38")]
+        :param int offset: skip this number of rows
+        :param int limit: include this number of rows
+        """
+
+        ORM = self.get_model(table_name=self.table_name)
+
+        with self.session as s:
+            if columns is not None:
+                statement = sqlmodel.select(*[getattr(ORM, column) for column in columns])
+            else:
+                statement = sqlmodel.select(ORM)
+
+            statement = dynamic_filter(
+                ORM=ORM,
+                statement=statement,
+                filter_conditions=filter_conditions,
+                json_filter_conditions=json_filter_conditions,
+            )
+            if isinstance(offset, int):
+                statement = statement.offset(offset)
+            if isinstance(limit, int):
+                statement = statement.limit(limit)
+            results = s.exec(statement)
+            result = results.all()
+
+        return result
+
     def select_txt(
         self,
         columns: Optional[List[str]] = None,

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -11,7 +11,7 @@ from sqlmodel import Session, create_engine, select as sql_select
 #     pass
 
 if int(sys.version.split(".")[1]) < 9:
-    from typing import List, Dict, Any, Optional, Union
+    from typing import List, Dict, Any, Optional, Union, NoReturn
 else:
     from typing import *
 

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -53,7 +53,7 @@ class DBBackend(PipestatBackend):
         :param dict status_schema_source: filepath of status schema
         :param str result_formatter: function for formatting result
         """
-        _LOGGER.warning(f"Initializing DBBackend for pipeline '{pieline_name}'")
+        _LOGGER.warning(f"Initializing DBBackend for pipeline '{pipeline_name}'")
         self.pipeline_name = pipeline_name
         self.pipeline_type = pipeline_type or "sample"
         self.record_identifier = record_identifier

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -373,52 +373,6 @@ class DBBackend(PipestatBackend):
             _LOGGER.error(f"Could not insert the result into the database. Exception: {e}")
             raise
 
-    def retrieve(
-        self,
-        record_identifier: Optional[str] = None,
-        result_identifier: Optional[str] = None,
-    ) -> Union[Any, Dict[str, Any]]:
-        """
-        Retrieve a result for a record.
-
-        If no result ID specified, results for the entire record will
-        be returned.
-
-        :param str record_identifier: unique identifier of the record
-        :param str result_identifier: name of the result to be retrieved
-        :return any | Dict[str, any]: a single result or a mapping with all the
-            results reported for the record
-        """
-
-        record_identifier = record_identifier or self.record_identifier
-
-        if result_identifier is not None:
-            existing = self.list_results(
-                record_identifier=record_identifier,
-                restrict_to=[result_identifier],
-            )
-            if not existing:
-                raise RecordNotFoundError(
-                    f"Result '{result_identifier}' not found for record " f"'{record_identifier}'"
-                )
-
-        with self.session as s:
-            record = (
-                s.query(self.get_model(table_name=self.table_name))
-                .filter_by(record_identifier=record_identifier)
-                .first()
-            )
-
-        if record is not None:
-            if result_identifier is not None:
-                return getattr(record, result_identifier)
-            return {
-                column: getattr(record, column)
-                for column in [c.name for c in record.__table__.columns]
-                if getattr(record, column, None) is not None
-            }
-        raise RecordNotFoundError(f"Record '{record_identifier}' not found")
-
     def select_records(
         self,
         columns: Optional[List[str]] = None,

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -640,6 +640,24 @@ class DBBackend(PipestatBackend):
 
         return records_dict
 
+    def select_distinct(
+        self,
+        columns,
+    ) -> List[Tuple]:
+        """
+        Perform a `SELECT DISTINCT` on given table and column
+
+        :param List[str] columns: columns to include in the result
+        :return List[Tuple]: returns distinct values.
+        """
+
+        ORM = self.get_model(table_name=self.table_name)
+        with self.session as s:
+            query = s.query(*[getattr(ORM, column) for column in columns])
+            query = query.distinct()
+            result = query.all()
+        return result
+
     def set_status(
         self,
         status_identifier: str,

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -629,7 +629,7 @@ class DBBackend(PipestatBackend):
         limit: Optional[int] = 1000,
         cursor: Optional[int] = None,
         bool_operator: Optional[str] = "AND",
-    ) -> List[Any]:
+    ) -> Dict[str, Any]:
         """
         Perform a `SELECT` on the table
 
@@ -642,7 +642,8 @@ class DBBackend(PipestatBackend):
             - like for like
         :param int limit: maximum number of results to retrieve per page
         :param int cursor: cursor position to begin retrieving records
-        :return dict[int,int,int,list]
+        :param bool bool_operator: Perform filtering with AND or OR Logic.
+        :return Dict[str, Any]
         """
 
         ORM = self.get_model(table_name=self.table_name)

--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -633,19 +633,16 @@ class DBBackend(PipestatBackend):
         """
         Perform a `SELECT` on the table
 
-        :param List[str] columns: columns to include in the result
-        :param [(key,operator,value)] filter_conditions: e.g. [("id", "eq", 1)], operator list:
+        :param list[str] columns: columns to include in the result
+        :param list[tuple(str,str,str)] [(key,operator,value)] filter_conditions: e.g. [("id", "eq", 1)], operator list:
             - eq for ==
             - lt for <
             - ge for >=
             - in for in_
             - like for like
-        :param [(col,key,value)] json_filter_conditions: conditions for JSONB column to
-            query that include JSON column name, key withing the JSON object in that
-            column and the value to check the identity against. Therefore only '==' is
-            supported in non-nested checks, e.g. [("other", "genome", "hg38")]
-        :param int offset: skip this number of rows
-        :param int limit: include this number of rows
+        :param int limit: maximum number of results to retrieve per page
+        :param int cursor: cursor position to begin retrieving records
+        :return dict[int,int,int,list]
         """
 
         ORM = self.get_model(table_name=self.table_name)

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -556,21 +556,21 @@ class FileBackend(PipestatBackend):
 
         if bool_operator.lower() == "or" and filtered_records_list:
             shared_keys = list(set(chain(*filtered_records_list)))
-
+        record = {}
         if shared_keys:
             for record_identifier in sorted(shared_keys):
                 if columns:  # Did the user specify a list of columns as well?
-                    for key in list(
+                    for key, value in list(
                         self._data.data[self.pipeline_name][self.pipeline_type][
                             record_identifier
-                        ].keys()
+                        ].items()
                     ):
-                        if key not in columns:
-                            self._data.data[self.pipeline_name][self.pipeline_type][
-                                record_identifier
-                            ].pop(key)
-
-                record = self._data.data[self.pipeline_name][self.pipeline_type][record_identifier]
+                        if key in columns:
+                            record.update({key: value})
+                else:
+                    record = self._data.data[self.pipeline_name][self.pipeline_type][
+                        record_identifier
+                    ]
                 record.update({"record_identifier": record_identifier})
                 records_list.append(record)
 

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -386,8 +386,11 @@ class FileBackend(PipestatBackend):
             _LOGGER.info(f"Overwriting existing results: {existing_str}")
             values.update({MODIFIED_TIME: current_time})
         if not existing:
-            values.update({CREATED_TIME: current_time})
-            values.update({MODIFIED_TIME: current_time})
+            if record_identifier in self._data[self.pipeline_name][self.pipeline_type].keys():
+                values.update({MODIFIED_TIME: current_time})
+            else:
+                values.update({CREATED_TIME: current_time})
+                values.update({MODIFIED_TIME: current_time})
 
         self._data[self.pipeline_name][self.pipeline_type].setdefault(record_identifier, {})
 

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -511,10 +511,14 @@ class FileBackend(PipestatBackend):
                             if key in CREATED_TIME or key in MODIFIED_TIME:
                                 try:
                                     time_stamp = datetime.datetime.strptime(
-                                        self._data.data[self.pipeline_name][self.pipeline_type][k][key],
+                                        self._data.data[self.pipeline_name][self.pipeline_type][k][
+                                            key
+                                        ],
                                         date_format,
                                     )
-                                    result = retrieved_operator(time_stamp, filter_condition["value"])
+                                    result = retrieved_operator(
+                                        time_stamp, filter_condition["value"]
+                                    )
                                 except TypeError:
                                     result = False
                             else:

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -211,7 +211,6 @@ class FileBackend(PipestatBackend):
             self.status_file_dir, f"{self.pipeline_name}_{r_id}_{status_identifier}.flag"
         )
 
-
     def list_results(
         self,
         restrict_to: Optional[List[str]] = None,
@@ -407,6 +406,71 @@ class FileBackend(PipestatBackend):
 
         return results_formatted
 
+    def select_records(
+        self,
+        columns: Optional[List[str]] = None,
+        filter_conditions: Optional[List[Dict[str, Any]]] = None,
+        limit: Optional[int] = 1000,
+        cursor: Optional[int] = None,
+        bool_operator: Optional[str] = "AND",
+    ) -> Dict[str, Any]:
+        """
+        Perform a `SELECT` on the table
+
+        :param list[str] columns: columns to include in the result
+        :param list[dict]  filter_conditions: e.g. [{"key": ["id"], "operator": "eq", "value": 1)], operator list:
+            - eq for ==
+            - lt for <
+            - ge for >=
+            - in for in_
+            - like for like
+        :param int limit: maximum number of results to retrieve per page
+        :param int cursor: cursor position to begin retrieving records
+        :param bool bool_operator: Perform filtering with AND or OR Logic.
+        :return Dict[str, Any]
+        """
+
+        # ORM = self.get_model(table_name=self.table_name)
+        #
+        # with self.session as s:
+        #     total_count = len(s.exec(sql_select(ORM)).all())
+        #
+        #     if columns is not None:
+        #         columns = ["id"] + columns  # Must add id, need it for cursor
+        #         statement = sqlmodel.select(
+        #             *[getattr(ORM, column) for column in columns]
+        #         ).order_by(ORM.id)
+        #     else:
+        #         statement = sqlmodel.select(ORM).order_by(ORM.id)
+        #
+        #     if cursor is not None:
+        #         statement = statement.where(ORM.id > cursor)
+        #
+        #     statement = selection_filter(
+        #         ORM=ORM,
+        #         statement=statement,
+        #         filter_conditions=filter_conditions,
+        #         bool_operator=bool_operator,
+        #     )
+        #
+        #     if isinstance(limit, int):
+        #         statement = statement.limit(limit)
+        #
+        #     results = s.exec(statement).all()
+        #
+        # if results != []:
+        #     next_cursor = results[-1].id
+        # else:
+        #     next_cursor = None
+
+        records_dict = {
+            "total_size": total_count,
+            "page_size": limit,
+            "next_page_token": next_cursor,
+            "records": results,
+        }
+
+        return records_dict
 
     def retrieve(
         self,

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -434,14 +434,19 @@ class FileBackend(PipestatBackend):
                         value = self._data.data[self.pipeline_name][self.pipeline_type][r_id][c]
                         record_value_list.append(value)
                     else:
-                        _LOGGER.warning(msg=f"Column {c} not reported, skipping....")
+                        if c != "record_identifier":
+                            _LOGGER.warning(msg=f"Column {c} not reported, skipping....")
+                if "record_identifier" in c:
+                    # record_identifier is not a column in the file backend but the user may want it
+                    record_value_list.append(r_id)
                 final_values_list.append(record_value_list)
 
-        print(final_values_list)
         unique_lists = []
         for list_of_samples in final_values_list:
             if tuple(list_of_samples) not in unique_lists:
-                unique_lists.append(tuple(list_of_samples)) # Convert to tuple to match DB backend output
+                unique_lists.append(
+                    tuple(list_of_samples)
+                )  # Convert to tuple to match DB backend output
 
         return unique_lists
 

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -583,40 +583,6 @@ class FileBackend(PipestatBackend):
 
         return records_dict
 
-    def retrieve(
-        self,
-        record_identifier: Optional[str] = None,
-        result_identifier: Optional[str] = None,
-    ) -> Union[Any, Dict[str, Any]]:
-        """
-        Retrieve a result for a record.
-
-        If no result ID specified, results for the entire record will
-        be returned.
-
-        :param str record_identifier: unique identifier of the record
-        :param str result_identifier: name of the result to be retrieved
-        :return any | Dict[str, any]: a single result or a mapping with all the
-            results reported for the record
-        """
-
-        record_identifier = record_identifier or self.record_identifier
-
-        if record_identifier not in self._data[self.pipeline_name][self.pipeline_type]:
-            raise RecordNotFoundError(f"Record '{record_identifier}' not found")
-        if result_identifier is None:
-            return self._data.exp[self.pipeline_name][self.pipeline_type][record_identifier]
-        if (
-            result_identifier
-            not in self._data[self.pipeline_name][self.pipeline_type][record_identifier]
-        ):
-            raise RecordNotFoundError(
-                f"Result '{result_identifier}' not found for record '{record_identifier}'"
-            )
-        return self._data[self.pipeline_name][self.pipeline_type][record_identifier][
-            result_identifier
-        ]
-
     def set_status(
         self,
         status_identifier: str,

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -145,37 +145,6 @@ class FileBackend(PipestatBackend):
             return None
         pass
 
-    def get_records(
-        self,
-        limit: Optional[int] = 1000,
-        offset: Optional[int] = 0,
-    ) -> Optional[dict]:
-        """Returns list of records
-        :param int limit: limit number of records to this amount
-        :param int offset: offset records by this amount
-        :return dict records_dict: dictionary of records
-        {
-          "count": x,
-          "limit": l,
-          "offset": o,
-          "records": [...]
-        }
-        """
-        record_list = []
-        all_records = list(self._data.data[self.pipeline_name][self.pipeline_type].keys())
-        total_count = len(all_records)
-        for record in all_records[offset : offset + limit]:
-            record_list.append(record)
-
-        records_dict = {
-            "count": total_count,
-            "limit": limit,
-            "offset": offset,
-            "records": record_list,
-        }
-
-        return records_dict
-
     def get_status(self, record_identifier: str) -> Optional[str]:
         """
         Get the current pipeline status
@@ -575,7 +544,7 @@ class FileBackend(PipestatBackend):
         else:
             # Assume user wants all the records if no filter was given.
             filtered_records_list = [
-                list(self._data.data[self.pipeline_name][self.pipeline_type].keys())
+                list(self._data.data[self.pipeline_name][self.pipeline_type].keys())[0:limit]
             ]
 
         # There is now a list of dicts for each filtered condition.

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -472,6 +472,8 @@ class FileBackend(PipestatBackend):
             else:
                 return get_nested_column(value[key_list[0]], key_list[1:])
 
+        date_format = "%Y-%m-%d %H:%M:%S"
+
         records_list = []
 
         result_identifier = columns
@@ -506,7 +508,17 @@ class FileBackend(PipestatBackend):
                         )
                     else:
                         if filter_condition["key"] == key:
-                            result = retrieved_operator(value, filter_condition["value"])
+                            if key in CREATED_TIME or key in MODIFIED_TIME:
+                                try:
+                                    time_stamp = datetime.datetime.strptime(
+                                        self._data.data[self.pipeline_name][self.pipeline_type][k][key],
+                                        date_format,
+                                    )
+                                    result = retrieved_operator(time_stamp, filter_condition["value"])
+                                except TypeError:
+                                    result = False
+                            else:
+                                result = retrieved_operator(value, filter_condition["value"])
                     if result is not False:
                         retrieved_results.append(k)
             if retrieved_results != []:

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -537,6 +537,9 @@ class FileBackend(PipestatBackend):
                 shared_keys.intersection_update(list_of_samples)
             if len(shared_keys) != 0:
                 for k in sorted(shared_keys):
+                    # for key in self._data.data[self.pipeline_name][self.pipeline_type][k].keys():
+                    #     if key not in result_identifier:
+                    #         del(self._data.data[self.pipeline_name][self.pipeline_type][k][key])
                     record = self._data.data[self.pipeline_name][self.pipeline_type][k]
                     record.update({"record_identifier": k})
                     records_list.append(record)

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -412,19 +412,38 @@ class FileBackend(PipestatBackend):
         columns,
     ) -> List[Tuple]:
         """
-        Perform a `SELECT DISTINCT` on given table and column
+        Retrieve distinct results given a list of columns
 
         :param List[str] columns: columns to include in the result
         :return List[Tuple]: returns distinct values.
         """
 
-        # ORM = self.get_model(table_name=self.table_name)
-        # with self.session as s:
-        #     query = s.query(*[getattr(ORM, column) for column in columns])
-        #     query = query.distinct()
-        #     result = query.all()
-        result = None
-        return result
+        if columns:
+            if not isinstance(columns, list):
+                raise ValueError(
+                    "Columns must be a list of strings, e.g. ['record_identifier', 'number_of_things']"
+                )
+
+            final_values_list = []
+            for r_id in self._data.data[self.pipeline_name][self.pipeline_type].keys():
+                record_value_list = []
+                for c in columns:
+                    if c in list(
+                        self._data.data[self.pipeline_name][self.pipeline_type][r_id].keys()
+                    ):
+                        value = self._data.data[self.pipeline_name][self.pipeline_type][r_id][c]
+                        record_value_list.append(value)
+                    else:
+                        _LOGGER.warning(msg=f"Column {c} not reported, skipping....")
+                final_values_list.append(record_value_list)
+
+        print(final_values_list)
+        unique_lists = []
+        for list_of_samples in final_values_list:
+            if tuple(list_of_samples) not in unique_lists:
+                unique_lists.append(tuple(list_of_samples)) # Convert to tuple to match DB backend output
+
+        return unique_lists
 
     def select_records(
         self,

--- a/pipestat/cli.py
+++ b/pipestat/cli.py
@@ -98,9 +98,9 @@ def main(test_args=None):
     types_to_read_from_json = ["object"] + list(CANONICAL_TYPES.keys())
     if args.command == REPORT_CMD:
         value = args.value
-        if psm.store[SCHEMA_KEY] is None:
+        if psm.cfg[SCHEMA_KEY] is None:
             raise SchemaNotFoundError(msg="report", cli=True)
-        result_metadata = psm.store[SCHEMA_KEY].results_data[args.result_identifier]
+        result_metadata = psm.cfg[SCHEMA_KEY].results_data[args.result_identifier]
         if result_metadata[SCHEMA_TYPE_KEY] in types_to_read_from_json:
             path_to_read = expandpath(value)
             if os.path.exists(path_to_read):

--- a/pipestat/cli.py
+++ b/pipestat/cli.py
@@ -98,9 +98,9 @@ def main(test_args=None):
     types_to_read_from_json = ["object"] + list(CANONICAL_TYPES.keys())
     if args.command == REPORT_CMD:
         value = args.value
-        if psm.schema is None:
+        if psm.store[SCHEMA_KEY] is None:
             raise SchemaNotFoundError(msg="report", cli=True)
-        result_metadata = psm.schema.results_data[args.result_identifier]
+        result_metadata = psm.store[SCHEMA_KEY].results_data[args.result_identifier]
         if result_metadata[SCHEMA_TYPE_KEY] in types_to_read_from_json:
             path_to_read = expandpath(value)
             if os.path.exists(path_to_read):

--- a/pipestat/const.py
+++ b/pipestat/const.py
@@ -12,6 +12,8 @@ if int(sys.version.split(".")[1]) < 9:
 else:
     list_of_dicts = list[dict]
 
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
 
 __all__ = [
     "CANONICAL_TYPES",

--- a/pipestat/exceptions.py
+++ b/pipestat/exceptions.py
@@ -18,12 +18,18 @@ __all__ = [
     "PipelineTypeNotSuppliedError",
     "InvalidTimeFormatError",
     "PipestatDependencyError",
+    "ColumnNotFoundError",
 ]
 
 
 class RecordNotFoundError(LookupError):
     def __init__(self, msg):
         super(RecordNotFoundError, self).__init__(msg)
+
+
+class ColumnNotFoundError(LookupError):
+    def __init__(self, msg):
+        super(ColumnNotFoundError, self).__init__(msg)
 
 
 class PipelineTypeNotSuppliedError(LookupError):

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -179,9 +179,7 @@ class PipestatManager(MutableMapping):
 
         self.cfg[MULTI_PIPELINE] = multi_pipelines
 
-        self.cfg[OUTPUT_DIR] = self.cfg[CONFIG_KEY].priority_get(
-            "output_dir", override=output_dir
-        )
+        self.cfg[OUTPUT_DIR] = self.cfg[CONFIG_KEY].priority_get("output_dir", override=output_dir)
 
         if self.cfg[FILE_KEY]:
             # file backend
@@ -661,7 +659,7 @@ class PipestatManager(MutableMapping):
 
         """
 
-        pipeline_name = self.pipeline_name
+        pipeline_name = self.cfg[PIPELINE_NAME]
         table_path_list = _create_stats_objs_summaries(self, pipeline_name)
 
         return table_path_list

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -555,7 +555,7 @@ class PipestatManager(MutableMapping):
     @require_backend
     def select_distinct(
         self,
-        columns: Optional[List[str]] = None,
+        columns: Optional[Union[str, List[str]]] = None,
     ) -> List[Any]:
         """
         Retrieves unique results for a list of attributes.
@@ -563,6 +563,10 @@ class PipestatManager(MutableMapping):
         :param List[str] columns: columns to include in the result
         :return list[any] result: this is a list of distinct results
         """
+        if not isinstance(columns, list) and not isinstance(columns, str):
+            raise ValueError(
+                "Columns must be a list of strings or string, e.g. ['record_identifier', 'number_of_things']"
+            )
 
         result = self.backend.select_distinct(columns=columns)
         return result

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -563,7 +563,6 @@ class PipestatManager(MutableMapping):
         self,
         columns: Optional[List[str]] = None,
         filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
-        json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
         limit: Optional[int] = 1000,
         cursor: Optional[int] = None,
         bool_operator: Optional[str] = "AND",
@@ -585,7 +584,6 @@ class PipestatManager(MutableMapping):
         return self.backend.select_records(
             columns=columns,
             filter_conditions=filter_conditions,
-            json_filter_conditions=json_filter_conditions,
             limit=limit,
             cursor=cursor,
             bool_operator=bool_operator,
@@ -602,8 +600,14 @@ class PipestatManager(MutableMapping):
         return a single record and its associated results
         """
 
-        filter_conditions = [("record_identifier", "eq", record_identifier)]
-        return self.backend.select_records(filter_conditions=filter_conditions)
+        filter_conditions = [
+            {
+                "key": "record_identifier",
+                "operator": "eq",
+                "value": record_identifier,
+            },
+        ]
+        return self.select_records(filter_conditions=filter_conditions)
 
     def retrieve_many(
         self,
@@ -616,20 +620,18 @@ class PipestatManager(MutableMapping):
 
         """
 
-        many_records = []
-        # for r_id in record_identifiers:
-        #     filter_conditions = [("record_identifier", "eq", r_id)]
-        #     many_records.append(self.backend.select_records(filter_conditions=filter_conditions))
         filter_conditions = []
         # For large list of recrds, we need ot use in operations.
         for r_id in record_identifiers:
-            filter_conditions.append(("record_identifier", "eq", r_id))
+            filter = {
+                "key": "record_identifier",
+                "operator": "eq",
+                "value": r_id,
+            }
 
-        many_records.append(
-            self.select_records(filter_conditions=filter_conditions, bool_operator="OR")
-        )
+            filter_conditions.append(filter)
 
-        return many_records
+        return self.select_records(filter_conditions=filter_conditions, bool_operator="OR")
 
     @require_backend
     def retrieve(

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -564,8 +564,8 @@ class PipestatManager(MutableMapping):
         columns: Optional[List[str]] = None,
         filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
         json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
+        limit: Optional[int] = 1000,
+        cursor: Optional[int] = None,
     ) -> List[Any]:
         """
         Retrieve a result for a record.
@@ -585,6 +585,8 @@ class PipestatManager(MutableMapping):
             columns=columns,
             filter_conditions=filter_conditions,
             json_filter_conditions=json_filter_conditions,
+            limit=limit,
+            cursor=cursor,
         )
 
     @require_backend

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -625,10 +625,8 @@ class PipestatManager(MutableMapping):
     @require_backend
     def retrieve(
         self,
-        record_identifier: Optional[Union[str, List[str]]] = None,
-        result_identifier: Optional[Union[str, List[str]]] = None,
-        limit: Optional[int] = 1000,
-        offset: Optional[int] = 0,
+        record_identifier: str = None,
+        result_identifier: str = None,
     ) -> Union[Any, Dict[str, Any]]:
         """
         Retrieve a result for a record.
@@ -643,21 +641,6 @@ class PipestatManager(MutableMapping):
         :return any | Dict[str, any]: a single result or a mapping with filtered
             results reported for the record
         """
-        if record_identifier is None and result_identifier is None:
-            # This will retrieve all records and columns.
-            return self.backend.retrieve_multiple(
-                record_identifier, result_identifier, limit, offset
-            )
-
-        if type(record_identifier) is list or type(result_identifier) is list:
-            if len(record_identifier) == 1 and len(result_identifier) == 1:
-                # If user gives single values, just use retrieve.
-                return self.backend.retrieve(record_identifier[0], result_identifier[0])
-            else:
-                # If user gives lists, retrieve_multiple
-                return self.backend.retrieve_multiple(
-                    record_identifier, result_identifier, limit, offset
-                )
 
         r_id = record_identifier or self.cfg[RECORD_IDENTIFIER]
 

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -395,9 +395,9 @@ class PipestatManager(MutableMapping):
                 raise InvalidTimeFormatError(msg=f"Incorrect time format, requires: {date_format}")
 
         if time_column == "created":
-            col_name = "pipestat_created_time"
+            col_name = CREATED_TIME
         else:
-            col_name = "pipestat_modified_time"
+            col_name = MODIFIED_TIME
         results = self.select_records(
             limit=limit,
             filter_conditions=[
@@ -553,7 +553,7 @@ class PipestatManager(MutableMapping):
         return reported_results
 
     @require_backend
-    def retrieve_distinct(
+    def select_distinct(
         self,
         columns: Optional[List[str]] = None,
     ) -> List[Any]:
@@ -563,11 +563,8 @@ class PipestatManager(MutableMapping):
         :param List[str] columns: columns to include in the result
         :return list[any] result: this is a list of distinct results
         """
-        if self.file:
-            # Not implemented yet
-            result = self.backend.retrieve_distinct()
-        else:
-            result = self.backend.select_distinct(columns=columns)
+
+        result = self.backend.select_distinct(columns=columns)
         return result
 
     @require_backend

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -562,7 +562,7 @@ class PipestatManager(MutableMapping):
     def select_records(
         self,
         columns: Optional[List[str]] = None,
-        filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
+        filter_conditions: Optional[List[Dict[str, Any]]] = None,
         limit: Optional[int] = 1000,
         cursor: Optional[int] = None,
         bool_operator: Optional[str] = "AND",

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -334,21 +334,6 @@ class PipestatManager(MutableMapping):
         return self.backend.count_records()
 
     @require_backend
-    def get_records(
-        self,
-        limit: Optional[int] = 1000,
-        offset: Optional[int] = 0,
-    ) -> Optional[dict]:
-        """
-        Returns list of records
-        :param int limit: limit number of records to this amount
-        :param int offset: offset records by this amount
-        :return dict: dictionary of records
-        """
-
-        return self.backend.get_records(limit=limit, offset=offset)
-
-    @require_backend
     def get_status(
         self,
         record_identifier: str = None,

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -570,7 +570,11 @@ class PipestatManager(MutableMapping):
                 "value": record_identifier,
             },
         ]
-        return self.select_records(filter_conditions=filter_conditions)
+        result = self.select_records(filter_conditions=filter_conditions)
+        if len(result["records"]) == 0:
+            raise RecordNotFoundError(f"Record '{record_identifier}' not found")
+        else:
+            return result
 
     def retrieve_many(
         self,
@@ -588,7 +592,12 @@ class PipestatManager(MutableMapping):
             "value": record_identifiers,
         }
 
-        return self.select_records(filter_conditions=[filter])
+        result = self.select_records(filter_conditions=[filter])
+
+        if len(result["records"]) == 0:
+            RecordNotFoundError(f"Records, '{record_identifiers}',  not found")
+        else:
+            return result
 
     @require_backend
     def set_status(

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -65,7 +65,7 @@ def require_backend(func):
     return inner
 
 
-class PipestatManager:
+class PipestatManager(MutableMapping):
     """
     Pipestat standardizes reporting of pipeline results and
     pipeline status management. It formalizes a way for pipeline developers

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -65,7 +65,7 @@ def require_backend(func):
     return inner
 
 
-class PipestatManager(MutableMapping):
+class PipestatManager():
     """
     Pipestat standardizes reporting of pipeline results and
     pipeline status management. It formalizes a way for pipeline developers

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -559,6 +559,67 @@ class PipestatManager(MutableMapping):
         return result
 
     @require_backend
+    def select_records(
+        self,
+        columns: Optional[List[str]] = None,
+        filter_conditions: Optional[List[Tuple[str, str, Union[str, List[str]]]]] = None,
+        json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> List[Any]:
+        """
+        Retrieve a result for a record.
+
+        If no result ID specified, results for the entire record will
+        be returned.
+
+        :param str | List[str] record_identifier: name of the sample_level record
+        :param str | List[str] result_identifier: name of the result to be retrieved
+        :param int limit: limit number of records to this amount
+        :param int offset: offset records by this amount
+        :return any | Dict[str, any]: a single result or a mapping with filtered
+            results reported for the record
+        """
+
+        return self.backend.select_records(
+            columns=columns,
+            filter_conditions=filter_conditions,
+            json_filter_conditions=json_filter_conditions,
+        )
+
+    @require_backend
+    def retrieve_one(
+        self,
+        record_identifier: str,
+    ) -> Union[Any, Dict[str, Any]]:
+        """
+        Retrieve a single record
+
+        return a single record and its associated results
+        """
+
+        filter_conditions = [("record_identifier", "eq", record_identifier)]
+        return self.backend.select_records(filter_conditions=filter_conditions)
+
+    def retrieve_many(
+        self,
+        record_identifiers: List[str],
+    ) -> Union[Any, Dict[str, Any]]:
+        """
+        Retrieve multiple records given a list of strings
+
+        returns list of records
+
+        """
+
+        many_records = []
+        for r_id in record_identifiers:
+            filter_conditions = [("record_identifier", "eq", r_id)]
+            many_records.append(self.backend.select_records(filter_conditions=filter_conditions))
+
+        return many_records
+
+    @require_backend
     def retrieve(
         self,
         record_identifier: Optional[Union[str, List[str]]] = None,

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -566,6 +566,7 @@ class PipestatManager(MutableMapping):
         json_filter_conditions: Optional[List[Tuple[str, str, str]]] = None,
         limit: Optional[int] = 1000,
         cursor: Optional[int] = None,
+        bool_operator: Optional[str] = "AND",
     ) -> List[Any]:
         """
         Retrieve a result for a record.
@@ -587,6 +588,7 @@ class PipestatManager(MutableMapping):
             json_filter_conditions=json_filter_conditions,
             limit=limit,
             cursor=cursor,
+            bool_operator=bool_operator,
         )
 
     @require_backend
@@ -615,9 +617,15 @@ class PipestatManager(MutableMapping):
         """
 
         many_records = []
+        # for r_id in record_identifiers:
+        #     filter_conditions = [("record_identifier", "eq", r_id)]
+        #     many_records.append(self.backend.select_records(filter_conditions=filter_conditions))
+        filter_conditions = []
+        # For large list of recrds, we need ot use in operations.
         for r_id in record_identifiers:
-            filter_conditions = [("record_identifier", "eq", r_id)]
-            many_records.append(self.backend.select_records(filter_conditions=filter_conditions))
+            filter_conditions.append(("record_identifier", "eq", r_id))
+
+        many_records.append(self.select_records(filter_conditions=filter_conditions, bool_operator="OR"))
 
         return many_records
 

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -65,7 +65,7 @@ def require_backend(func):
     return inner
 
 
-class PipestatManager():
+class PipestatManager:
     """
     Pipestat standardizes reporting of pipeline results and
     pipeline status management. It formalizes a way for pipeline developers

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -224,7 +224,7 @@ class PipestatManager(MutableMapping):
 
     def __getitem__(self, key):
         # This is a wrapper for the retrieve function:
-        result = self.retrieve(record_identifier=key)
+        result = self.retrieve_one(record_identifier=key)
         return result
 
     def __setitem__(self, key, value):
@@ -589,30 +589,6 @@ class PipestatManager(MutableMapping):
         }
 
         return self.select_records(filter_conditions=[filter])
-
-    @require_backend
-    def retrieve(
-        self,
-        record_identifier: str = None,
-        result_identifier: str = None,
-    ) -> Union[Any, Dict[str, Any]]:
-        """
-        Retrieve a result for a record.
-
-        If no result ID specified, results for the entire record will
-        be returned.
-
-        :param str | List[str] record_identifier: name of the sample_level record
-        :param str | List[str] result_identifier: name of the result to be retrieved
-        :param int limit: limit number of records to this amount
-        :param int offset: offset records by this amount
-        :return any | Dict[str, any]: a single result or a mapping with filtered
-            results reported for the record
-        """
-
-        r_id = record_identifier or self.cfg[RECORD_IDENTIFIER]
-
-        return self.backend.retrieve(r_id, result_identifier)
 
     @require_backend
     def set_status(

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -620,18 +620,13 @@ class PipestatManager(MutableMapping):
 
         """
 
-        filter_conditions = []
-        # For large list of recrds, we need ot use in operations.
-        for r_id in record_identifiers:
-            filter = {
-                "key": "record_identifier",
-                "operator": "eq",
-                "value": r_id,
-            }
+        filter = {
+            "key": "record_identifier",
+            "operator": "in",
+            "value": record_identifiers,
+        }
 
-            filter_conditions.append(filter)
-
-        return self.select_records(filter_conditions=filter_conditions, bool_operator="OR")
+        return self.select_records(filter_conditions=[filter])
 
     @require_backend
     def retrieve(

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -220,7 +220,7 @@ class PipestatManager(MutableMapping):
         res += f"\nStatus Schema key: {self.cfg[STATUS_SCHEMA_KEY]}"
         res += f"\nResults formatter: {str(self.cfg[RESULT_FORMATTER].__name__)}"
         res += f"\nResults schema source: {self.cfg[SCHEMA_PATH]}"
-        res += f"\nStatus schema source: {self.status_schema_source}"
+        res += f"\nStatus schema source: {self.cfg[STATUS_SCHEMA_SOURCE_KEY]}"
         res += f"\nRecords count: {self.record_count}"
         if self.cfg[SCHEMA_PATH] is not None:
             high_res = self.highlighted_results
@@ -231,14 +231,14 @@ class PipestatManager(MutableMapping):
         return res
 
     def __getitem__(self, key):
-        # return self.cfg[self._keytransform(key)]
-        print(key)
+        # This is a wrapper for the retrieve function:
+        result = self.retrieve(record_identifier=key)
+        return result
 
     def __setitem__(self, key, value):
         # This is a wrapper for the report function:
         result = self.report(record_identifier=key, values=value)
         return result
-
 
     def __delitem__(self, key):
         del self.cfg[self._keytransform(key)]
@@ -488,7 +488,7 @@ class PipestatManager(MutableMapping):
         :return bool: whether the result has been removed
         """
 
-        r_id = record_identifier or self.record_identifier
+        r_id = record_identifier or self.cfg[RECORD_IDENTIFIER]
         return self.backend.remove(
             record_identifier=r_id,
             result_identifier=result_identifier,
@@ -518,7 +518,7 @@ class PipestatManager(MutableMapping):
         :return str reported_results: return list of formatted string
         """
 
-        result_formatter = result_formatter or self[RESULT_FORMATTER]
+        result_formatter = result_formatter or self.cfg[RESULT_FORMATTER]
         values = deepcopy(values)
         r_id = record_identifier or self.cfg[RECORD_IDENTIFIER]
         if r_id is None:
@@ -595,7 +595,7 @@ class PipestatManager(MutableMapping):
                     record_identifier, result_identifier, limit, offset
                 )
 
-        r_id = record_identifier or self.record_identifier
+        r_id = record_identifier or self.cfg[RECORD_IDENTIFIER]
 
         return self.backend.retrieve(r_id, result_identifier)
 

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -235,9 +235,10 @@ class PipestatManager(MutableMapping):
         print(key)
 
     def __setitem__(self, key, value):
-        # self.cfg[self._keytransform(key)] = value
-        print(key)
-        # self.report()
+        # This is a wrapper for the report function:
+        result = self.report(record_identifier=key, values=value)
+        return result
+
 
     def __delitem__(self, key):
         del self.cfg[self._keytransform(key)]

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -625,7 +625,9 @@ class PipestatManager(MutableMapping):
         for r_id in record_identifiers:
             filter_conditions.append(("record_identifier", "eq", r_id))
 
-        many_records.append(self.select_records(filter_conditions=filter_conditions, bool_operator="OR"))
+        many_records.append(
+            self.select_records(filter_conditions=filter_conditions, bool_operator="OR")
+        )
 
         return many_records
 

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -33,7 +33,7 @@ class HTMLReportBuilder(object):
         self.prj = prj
         self.jinja_env = get_jinja_env()
         results_file_path = getattr(self.prj.backend, "results_file_path", None)
-        config_path = getattr(self.prj, "config_path", None)
+        config_path = self.prj.store.get('config_path', None)
         output_dir = getattr(self.prj, "output_dir", None)
         self.output_dir = output_dir or results_file_path or config_path
         self.output_dir = os.path.dirname(self.output_dir)
@@ -1011,7 +1011,7 @@ def get_file_for_table(prj, pipeline_name, appendix=None, directory=None):
     """
     # TODO make determining the output_dir its own small function since we use the same code in HTML report building.
     results_file_path = getattr(prj.backend, "results_file_path", None)
-    config_path = getattr(prj, "config_path", None)
+    config_path = prj.store.get("config_path", None)
     output_dir = getattr(prj, "output_dir", None)
     table_dir = output_dir or results_file_path or config_path
     if not os.path.isdir(table_dir):

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -33,8 +33,8 @@ class HTMLReportBuilder(object):
         self.prj = prj
         self.jinja_env = get_jinja_env()
         results_file_path = getattr(self.prj.backend, "results_file_path", None)
-        config_path = self.prj.store.get("config_path", None)
-        output_dir = getattr(self.prj.store[OUTPUT_DIR], "output_dir", None)
+        config_path = self.prj.cfg.get("config_path", None)
+        output_dir = getattr(self.prj.cfg[OUTPUT_DIR], "output_dir", None)
         self.output_dir = output_dir or results_file_path or config_path
         self.output_dir = os.path.dirname(self.output_dir)
         self.reports_dir = os.path.join(self.output_dir, "reports")
@@ -1011,7 +1011,7 @@ def get_file_for_table(prj, pipeline_name, appendix=None, directory=None):
     """
     # TODO make determining the output_dir its own small function since we use the same code in HTML report building.
     results_file_path = getattr(prj.backend, "results_file_path", None)
-    config_path = prj.store.get("config_path", None)
+    config_path = prj.cfg.get("config_path", None)
     output_dir = getattr(prj, "output_dir", None)
     table_dir = output_dir or results_file_path or config_path
     if not os.path.isdir(table_dir):

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -33,8 +33,8 @@ class HTMLReportBuilder(object):
         self.prj = prj
         self.jinja_env = get_jinja_env()
         results_file_path = getattr(self.prj.backend, "results_file_path", None)
-        config_path = self.prj.store.get('config_path', None)
-        output_dir = getattr(self.prj, "output_dir", None)
+        config_path = self.prj.store.get("config_path", None)
+        output_dir = getattr(self.prj.store[OUTPUT_DIR], "output_dir", None)
         self.output_dir = output_dir or results_file_path or config_path
         self.output_dir = os.path.dirname(self.output_dir)
         self.reports_dir = os.path.join(self.output_dir, "reports")

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -384,7 +384,7 @@ class HTMLReportBuilder(object):
                 flag = flag_dict["flag"]
         highlighted_results = fetch_pipeline_results(
             project=self.prj,
-            pipeline_name=self.prj.pipeline_name,
+            pipeline_name=self.prj.cfg[PIPELINE_NAME],
             sample_name=sample_name,
             inclusion_fun=lambda x: x == "file",
             highlighted=True,
@@ -482,7 +482,7 @@ class HTMLReportBuilder(object):
         # Add stats_summary.tsv button link
         stats_file_path = get_file_for_project(
             prj=self.prj,
-            pipeline_name=self.prj.pipeline_name,
+            pipeline_name=self.prj.cfg[PIPELINE_NAME],
             appendix="stats_summary.tsv",
             reportdir=self.reports_dir,
         )
@@ -495,7 +495,7 @@ class HTMLReportBuilder(object):
         # Add objects_summary.yaml button link
         objs_file_path = get_file_for_project(
             prj=self.prj,
-            pipeline_name=self.prj.pipeline_name,
+            pipeline_name=self.prj.cfg[PIPELINE_NAME],
             appendix="objs_summary.yaml",
             reportdir=self.reports_dir,
         )
@@ -548,7 +548,7 @@ class HTMLReportBuilder(object):
         )
         # Create status page with each sample's status listed
         status_tab = create_status_table(
-            pipeline_name=self.prj.pipeline_name,
+            pipeline_name=self.prj.cfg[PIPELINE_NAME],
             project=self.prj,
             pipeline_reports_dir=self.pipeline_reports,
         )
@@ -571,8 +571,8 @@ class HTMLReportBuilder(object):
             columns=columns,
             columns_json=dumps(columns),
             table_row_data=table_row_data,
-            project_name=self.prj.project_name,
-            pipeline_name=self.prj.pipeline_name,
+            project_name=self.prj.cfg[PROJECT_NAME],
+            pipeline_name=self.prj.cfg[PIPELINE_NAME],
             stats_json=self._stats_to_json_str(),
             footer=footer,
             amendments="",
@@ -619,7 +619,7 @@ class HTMLReportBuilder(object):
             results[sample_name] = fetch_pipeline_results(
                 project=self.prj,
                 sample_name=sample_name,
-                pipeline_name=self.prj.pipeline_name,
+                pipeline_name=self.prj.cfg[PIPELINE_NAME],
                 inclusion_fun=lambda x: x not in OBJECT_TYPES,
                 casting_fun=str,
             )
@@ -983,10 +983,10 @@ def get_file_for_project(prj, pipeline_name, appendix=None, directory=None, repo
         output_dir = output_dir or results_file_path or config_path
         output_dir = os.path.dirname(output_dir)
         reportdir = os.path.join(output_dir, "reports")
-    if prj["project_name"] is None:
+    if prj.cfg["project_name"] is None:
         fp = os.path.join(reportdir, directory or "", f"NO_PROJECT_NAME_{pipeline_name}")
     else:
-        fp = os.path.join(reportdir, directory or "", f"{prj['project_name']}_{pipeline_name}")
+        fp = os.path.join(reportdir, directory or "", f"{prj.cfg['project_name']}_{pipeline_name}")
 
     if hasattr(prj, "amendments") and getattr(prj, "amendments"):
         fp += f"_{'_'.join(prj.amendments)}"
@@ -1040,7 +1040,7 @@ def _create_stats_objs_summaries(prj, pipeline_name) -> List[str]:
     reported_stats = []
     stats = []
 
-    if prj.pipeline_type == "sample":
+    if prj.cfg[PIPELINE_TYPE] == "sample":
         columns = ["Sample Index", "Sample Name", "Results"]
     else:
         columns = ["Sample Index", "Project Name", "Sample Name", "Results"]
@@ -1051,7 +1051,7 @@ def _create_stats_objs_summaries(prj, pipeline_name) -> List[str]:
         record_index += 1
         record_name = record
 
-        if prj.pipeline_type == "sample":
+        if prj.cfg[PIPELINE_TYPE] == "sample":
             reported_stats = [record_index, record_name]
             rep_data = prj.retrieve(record_identifier=record_name)
         else:

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -119,8 +119,8 @@ class HTMLReportBuilder(object):
             os.makedirs(self.pipeline_reports)
         pages = []
         labels = []
-        for sample in self.prj.backend.get_records()["records"]:
-            sample_name = sample
+        for sample in self.prj.backend.select_records()["records"]:
+            sample_name = sample["record_identifier"]
             sample_dir = self.pipeline_reports
 
             # Confirm sample directory exists, then build page
@@ -259,8 +259,8 @@ class HTMLReportBuilder(object):
             links = []
             html_page_path = os.path.join(self.pipeline_reports, f"{file_result}.html".lower())
 
-            for sample in self.prj.backend.get_records()["records"]:
-                sample_name = sample
+            for sample in self.prj.backend.select_records()["records"]:
+                sample_name = sample["record_identifier"]
                 sample_result = fetch_pipeline_results(
                     project=self.prj,
                     pipeline_name=self.pipeline_name,
@@ -303,8 +303,8 @@ class HTMLReportBuilder(object):
             html_page_path = os.path.join(self.pipeline_reports, f"{image_result}.html".lower())
             figures = []
 
-            for sample in self.prj.backend.get_records()["records"]:
-                sample_name = sample
+            for sample in self.prj.backend.select_records()["records"]:
+                sample_name = sample["record_identifier"]
                 sample_result = fetch_pipeline_results(
                     project=self.prj,
                     pipeline_name=self.pipeline_name,
@@ -510,8 +510,8 @@ class HTMLReportBuilder(object):
         # Produce table rows
         table_row_data = []
         _LOGGER.info(" * Creating sample pages")
-        for sample in self.prj.backend.get_records()["records"]:
-            sample_name = sample
+        for sample in self.prj.backend.select_records()["records"]:
+            sample_name = sample["record_identifier"]
             sample_stat_results = fetch_pipeline_results(
                 project=self.prj,
                 pipeline_name=self.pipeline_name,
@@ -614,8 +614,8 @@ class HTMLReportBuilder(object):
 
     def _stats_to_json_str(self):
         results = {}
-        for sample in self.prj.backend.get_records()["records"]:
-            sample_name = sample
+        for sample in self.prj.backend.select_records()["records"]:
+            sample_name = sample["record_identifier"]
             results[sample_name] = fetch_pipeline_results(
                 project=self.prj,
                 sample_name=sample_name,
@@ -641,8 +641,8 @@ class HTMLReportBuilder(object):
     def _get_navbar_dropdown_data_samples(self, wd, context):
         relpaths = []
         sample_names = []
-        for sample in self.prj.backend.get_records()["records"]:
-            sample_name = sample
+        for sample in self.prj.backend.select_records()["records"]:
+            sample_name = sample["record_identifier"]
             page_name = os.path.join(
                 self.pipeline_reports,
                 f"{sample_name}.html".replace(" ", "_").lower(),
@@ -862,8 +862,8 @@ def create_status_table(project, pipeline_name, pipeline_reports_dir):
     times = []
     mems = []
     status_descs = []
-    for sample in project.backend.get_records()["records"]:
-        sample_name = sample
+    for sample in project.backend.select_records()["records"]:
+        sample_name = sample["record_identifier"]
         psm = project
         sample_names.append(sample_name)
         # status and status style
@@ -1045,11 +1045,11 @@ def _create_stats_objs_summaries(prj, pipeline_name) -> List[str]:
     else:
         columns = ["Sample Index", "Project Name", "Sample Name", "Results"]
 
-    records = prj.backend.get_records()["records"]
+    records = prj.backend.select_records()["records"]
     record_index = 0
     for record in records:
         record_index += 1
-        record_name = record
+        record_name = record["record_identifier"]
 
         if prj.cfg[PIPELINE_TYPE] == "sample":
             reported_stats = [record_index, record_name]

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -817,7 +817,7 @@ def fetch_pipeline_results(
     casting_fun = casting_fun or pass_all_fun
     psm = project
     # exclude object-like results from the stats results mapping
-    rep_data = psm.retrieve(record_identifier=sample_name)
+    rep_data = psm.retrieve_one(record_identifier=sample_name)
     results = {
         k: casting_fun(v)
         for k, v in rep_data.items()
@@ -881,7 +881,7 @@ def create_status_table(project, pipeline_name, pipeline_reports_dir):
         sample_paths.append(f"{sample_name}.html".replace(" ", "_").lower())
         # log file path
         try:
-            log = psm.retrieve(result_identifier="log")["path"]
+            log = psm.retrieve_one(result_identifier="log")["path"]
             assert os.path.exists(log), FileNotFoundError(f"Not found: {log}")
             log_link_names.append(os.path.basename(log))
             log_paths.append(os.path.relpath(log, pipeline_reports_dir))
@@ -891,7 +891,7 @@ def create_status_table(project, pipeline_name, pipeline_reports_dir):
             log_paths.append("")
         # runtime and peak mem
         try:
-            profile = psm.retrieve(result_identifier="profile")["path"]
+            profile = psm.retrieve_one(result_identifier="profile")["path"]
             assert os.path.exists(profile), FileNotFoundError(f"Not found: {profile}")
             df = _pd.read_csv(profile, sep="\t", comment="#", names=PROFILE_COLNAMES)
             df["runtime"] = _pd.to_timedelta(df["runtime"])
@@ -1053,9 +1053,9 @@ def _create_stats_objs_summaries(prj, pipeline_name) -> List[str]:
 
         if prj.cfg[PIPELINE_TYPE] == "sample":
             reported_stats = [record_index, record_name]
-            rep_data = prj.retrieve(record_identifier=record_name)
+            rep_data = prj.retrieve_one(record_identifier=record_name)
         else:
-            rep_data = prj.retrieve(record_identifier=record_name)
+            rep_data = prj.retrieve_one(record_identifier=record_name)
             reported_stats = [
                 record_index,
                 prj.cfg[PROJECT_NAME] or "No Project Name Supplied",

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -1012,11 +1012,11 @@ def get_file_for_table(prj, pipeline_name, appendix=None, directory=None):
     # TODO make determining the output_dir its own small function since we use the same code in HTML report building.
     results_file_path = getattr(prj.backend, "results_file_path", None)
     config_path = prj.cfg.get("config_path", None)
-    output_dir = getattr(prj, "output_dir", None)
+    output_dir = prj.cfg.get("output_dir", None)
     table_dir = output_dir or results_file_path or config_path
     if not os.path.isdir(table_dir):
         table_dir = os.path.dirname(table_dir)
-    fp = os.path.join(table_dir, directory or "", f"{prj[PROJECT_NAME]}_{pipeline_name}")
+    fp = os.path.join(table_dir, directory or "", f"{prj.cfg[PROJECT_NAME]}_{pipeline_name}")
     if hasattr(prj, "amendments") and getattr(prj, "amendments"):
         fp += f"_{'_'.join(prj.amendments)}"
     fp += f"_{appendix}"
@@ -1058,7 +1058,7 @@ def _create_stats_objs_summaries(prj, pipeline_name) -> List[str]:
             rep_data = prj.retrieve(record_identifier=record_name)
             reported_stats = [
                 record_index,
-                prj.project_name or "No Project Name Supplied",
+                prj.cfg[PROJECT_NAME] or "No Project Name Supplied",
                 record_name,
             ]
 

--- a/tests/data/sample_output_schema.yaml
+++ b/tests/data/sample_output_schema.yaml
@@ -22,3 +22,14 @@ samples:
     type: string
     description: "MD5SUM of an object"
     highlight: true
+#  output_file_in_object:
+#    type: object
+#    description: "This is an example file"
+#    properties:
+#      prop1:
+#        description: "This is an example file"
+#        type: object
+#        properties:
+#          prop2:
+#            description: "This is an example file"
+#            type: integer

--- a/tests/data/sample_output_schema.yaml
+++ b/tests/data/sample_output_schema.yaml
@@ -22,14 +22,3 @@ samples:
     type: string
     description: "MD5SUM of an object"
     highlight: true
-#  output_file_in_object:
-#    type: object
-#    description: "This is an example file"
-#    properties:
-#      prop1:
-#        description: "This is an example file"
-#        type: object
-#        properties:
-#          prop2:
-#            description: "This is an example file"
-#            type: integer

--- a/tests/data/sample_output_schema_recursive.yaml
+++ b/tests/data/sample_output_schema_recursive.yaml
@@ -24,3 +24,30 @@ samples:
   output_image:
     type: image
     description: "This a path to the output image"
+  number_of_things:
+    type: integer
+    description: "Number of things"
+  percentage_of_things:
+    type: number
+    description: "Percentage of things"
+  name_of_something:
+    type: string
+    description: "Name of something"
+  switch_value:
+    type: boolean
+    description: "Is the switch on or off"
+  md5sum:
+    type: string
+    description: "MD5SUM of an object"
+    highlight: true
+  output_file_in_object_nested:
+    type: object
+    description: "This is an example file"
+    properties:
+      prop1:
+        description: "This is an example file"
+        type: object
+        properties:
+          prop2:
+            description: "This is an example file"
+            type: integer

--- a/tests/data/sample_output_schema_recursive.yaml
+++ b/tests/data/sample_output_schema_recursive.yaml
@@ -6,6 +6,22 @@ properties:
   samples:
     type: object
     properties:
+      number_of_things:
+        type: integer
+        description: "Number of things"
+      percentage_of_things:
+        type: number
+        description: "Percentage of things"
+      name_of_something:
+        type: string
+        description: "Name of something"
+      switch_value:
+        type: boolean
+        description: "Is the switch on or off"
+      md5sum:
+        type: string
+        description: "MD5SUM of an object"
+        highlight: true
       collection_of_images:
         description: "This store collection of values or objects"
         type: array
@@ -24,6 +40,17 @@ properties:
             description: "This is an example image"
             $ref: "#/$defs/image"
         description: "Object output"
+      output_file_in_object_nested:
+        type: object
+        description: First Level
+        properties:
+          prop1:
+            type: object
+            description: Second Level
+            properties:
+              prop2:
+                type: integer
+                description: Third Level
       output_file:
         $ref: "#/$defs/file"
         description: "This a path to the output file"

--- a/tests/test_db_only_mode.py
+++ b/tests/test_db_only_mode.py
@@ -93,7 +93,7 @@ class TestDatabaseOnly:
             )
             val_name = list(val.keys())[0]
             if pipeline_type is True:
-                if val_name in psm.store[SCHEMA_KEY].project_level_data:
+                if val_name in psm.cfg[SCHEMA_KEY].project_level_data:
                     psm.report(
                         values=val,
                         force_overwrite=True,
@@ -105,7 +105,7 @@ class TestDatabaseOnly:
                     pass
                     # assert that this would fail to report otherwise.
             if pipeline_type == "sample":
-                if val_name in psm.store[SCHEMA_KEY].sample_level_data:
+                if val_name in psm.cfg[SCHEMA_KEY].sample_level_data:
                     psm.report(
                         values=val,
                         force_overwrite=True,

--- a/tests/test_db_only_mode.py
+++ b/tests/test_db_only_mode.py
@@ -93,7 +93,7 @@ class TestDatabaseOnly:
             )
             val_name = list(val.keys())[0]
             if pipeline_type is True:
-                if val_name in psm.schema.project_level_data:
+                if val_name in psm.store[SCHEMA_KEY].project_level_data:
                     psm.report(
                         values=val,
                         force_overwrite=True,
@@ -105,7 +105,7 @@ class TestDatabaseOnly:
                     pass
                     # assert that this would fail to report otherwise.
             if pipeline_type == "sample":
-                if val_name in psm.schema.sample_level_data:
+                if val_name in psm.store[SCHEMA_KEY].sample_level_data:
                     psm.report(
                         values=val,
                         force_overwrite=True,

--- a/tests/test_db_only_mode.py
+++ b/tests/test_db_only_mode.py
@@ -274,30 +274,3 @@ class TestDatabaseOnly:
             result = psm.select_records(cursor=offset, limit=limit)
             print(result)
             assert len(result["records"]) == min(max((psm.record_count - offset), 0), limit)
-
-    @pytest.mark.parametrize(
-        "val",
-        [
-            {"name_of_something": "test_name"},
-            {"number_of_things": 1},
-            {"percentage_of_things": 10.1},
-        ],
-    )
-    def test_select_txt(
-        self,
-        val,
-        config_file_path,
-        schema_file_path,
-    ):
-        with ContextManagerDBTesting(DB_URL):
-            psm = SamplePipestatManager(
-                schema_path=schema_file_path,
-                record_identifier="constant_record_id",
-                database_only=True,
-                config_file=config_file_path,
-            )
-            psm.report(record_identifier="constant_record_id", values=val, force_overwrite=True)
-            val_name = list(val.keys())[0]
-            # assert psm.backend.select(filter_conditions=[(val_name, "eq", val[val_name])])[0]
-            assert val_name in str(psm.backend.select_txt())
-            assert val_name not in str(psm.backend.select_txt(offset=2))

--- a/tests/test_db_only_mode.py
+++ b/tests/test_db_only_mode.py
@@ -66,7 +66,16 @@ class TestDatabaseOnly:
             )
             psm.report(record_identifier="constant_record_id", values=val, force_overwrite=True)
             val_name = list(val.keys())[0]
-            assert psm.backend.select(filter_conditions=[(val_name, "eq", val[val_name])])
+
+            assert psm.select_records(
+                filter_conditions=[
+                    {
+                        "key": val_name,
+                        "operator": "eq",
+                        "value": val[val_name],
+                    },
+                ],
+            )
 
     @pytest.mark.parametrize(
         "val",
@@ -172,7 +181,15 @@ class TestDatabaseOnly:
                 record_identifier=REC_ID, values=val, force_overwrite=True
             )  # Force overwrite so that resetting the SQL DB is unnecessary.
             val_name = list(val.keys())[0]
-            assert psm.backend.select(json_filter_conditions=[(val_name, "eq", val[val_name])])
+            assert psm.select_records(
+                filter_conditions=[
+                    {
+                        "key": val_name,
+                        "operator": "eq",
+                        "value": val[val_name],
+                    }
+                ]
+            )
 
     @pytest.mark.parametrize(["rec_id", "res_id"], [("sample2", "number_of_things")])
     def test_select_invalid_filter_column__raises_expected_exception(
@@ -186,9 +203,15 @@ class TestDatabaseOnly:
             args = dict(schema_path=schema_file_path, config_file=config_file_path)
             psm = SamplePipestatManager(**args)
             with pytest.raises(ValueError):
-                psm.backend.select(
-                    filter_conditions=[("bogus_column", "eq", rec_id)],
+                assert psm.select_records(
                     columns=[res_id],
+                    filter_conditions=[
+                        {
+                            "key": "bogus_name",
+                            "operator": "eq",
+                            "value": rec_id,
+                        },
+                    ],
                 )
 
     @pytest.mark.parametrize("res_id", ["number_of_things"])
@@ -203,8 +226,8 @@ class TestDatabaseOnly:
         with ContextManagerDBTesting(DB_URL):
             args = dict(schema_path=schema_file_path, config_file=config_file_path)
             psm = SamplePipestatManager(**args)
-            with pytest.raises((ValueError, TypeError)):
-                psm.backend.select(
+            with pytest.raises(AttributeError):
+                psm.select_records(
                     filter_conditions=[filter_condition],
                     columns=[res_id],
                 )
@@ -222,26 +245,18 @@ class TestDatabaseOnly:
         with ContextManagerDBTesting(DB_URL):
             args = dict(schema_path=schema_file_path, config_file=config_file_path)
             psm = SamplePipestatManager(**args)
-            result = psm.backend.select(
-                filter_conditions=[("record_identifier", "eq", rec_id)],
+            result = psm.select_records(
+                filter_conditions=[
+                    {
+                        "key": "record_identifier",
+                        "operator": "eq",
+                        "value": rec_id,
+                    }
+                ],
                 columns=[res_id],
                 limit=limit,
             )
-            assert len(result) <= limit
-
-    @pytest.mark.parametrize("offset", [0, 1, 2, 3, 15555])
-    def test_select_offset(
-        self,
-        config_file_path,
-        schema_file_path,
-        offset,
-    ):
-        with ContextManagerDBTesting(DB_URL):
-            args = dict(schema_path=schema_file_path, config_file=config_file_path)
-            psm = SamplePipestatManager(**args)
-            result = psm.backend.select(offset=offset)
-            print(result)
-            assert len(result) == max((psm.record_count - offset), 0)
+            assert len(result["records"]) <= limit
 
     @pytest.mark.parametrize(
         ["offset", "limit"], [(0, 0), (0, 1), (0, 2), (0, 11111), (1, 1), (1, 0)]
@@ -256,9 +271,9 @@ class TestDatabaseOnly:
         with ContextManagerDBTesting(DB_URL):
             args = dict(schema_path=schema_file_path, config_file=config_file_path)
             psm = SamplePipestatManager(**args)
-            result = psm.backend.select(offset=offset, limit=limit)
+            result = psm.select_records(cursor=offset, limit=limit)
             print(result)
-            assert len(result) == min(max((psm.record_count - offset), 0), limit)
+            assert len(result["records"]) == min(max((psm.record_count - offset), 0), limit)
 
     @pytest.mark.parametrize(
         "val",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,7 +11,7 @@ from pipestat.parsed_schema import SCHEMA_PIPELINE_NAME_KEY
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from .conftest import STANDARD_TEST_PIPE_ID
 from pipestat.helpers import init_generic_config
-from pipestat.const import PIPESTAT_GENERIC_CONFIG
+from pipestat.const import PIPESTAT_GENERIC_CONFIG, SCHEMA_KEY
 
 
 class TestPipestatManagerInstantiation:
@@ -93,7 +93,7 @@ class TestPipestatManagerInstantiation:
         assert os.path.exists(tmp_res_file)
         with open(schema_file_path, "r") as init_schema_file:
             init_schema = oyaml.safe_load(init_schema_file)
-        assert psm1.schema.pipeline_name == init_schema[SCHEMA_PIPELINE_NAME_KEY]
+        assert psm1.store[SCHEMA_KEY].pipeline_name == init_schema[SCHEMA_PIPELINE_NAME_KEY]
         ns2 = "namespace2"
         temp_schema_path = str(tmp_path / "schema.yaml")
         init_schema[SCHEMA_PIPELINE_NAME_KEY] = ns2
@@ -105,7 +105,7 @@ class TestPipestatManagerInstantiation:
                 schema_path=temp_schema_path,
             )
         # exp_msg = f"'{tmp_res_file}' is already used to report results for a different (not {ns2}) namespace: {psm1.schema.pipeline_name}"
-        exp_msg = f"'{tmp_res_file}' is already in use for 1 namespaces: {psm1.schema.pipeline_name} and multi_pipelines = False."
+        exp_msg = f"'{tmp_res_file}' is already in use for 1 namespaces: {psm1.store[SCHEMA_KEY].pipeline_name} and multi_pipelines = False."
         obs_msg = str(exc_ctx.value)
         assert obs_msg == exp_msg
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -98,8 +98,11 @@ class TestPipestatManagerInstantiation:
         with open(schema_file_path, "r") as init_schema_file:
             init_schema = oyaml.safe_load(init_schema_file)
 
-        assert psm1.cfg[SCHEMA_KEY].pipeline_name == init_schema["properties"][SCHEMA_PIPELINE_NAME_KEY]
-        
+        assert (
+            psm1.cfg[SCHEMA_KEY].pipeline_name
+            == init_schema["properties"][SCHEMA_PIPELINE_NAME_KEY]
+        )
+
         ns2 = "namespace2"
         temp_schema_path = str(tmp_path / "schema.yaml")
         init_schema["properties"][SCHEMA_PIPELINE_NAME_KEY] = ns2

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -93,7 +93,7 @@ class TestPipestatManagerInstantiation:
         assert os.path.exists(tmp_res_file)
         with open(schema_file_path, "r") as init_schema_file:
             init_schema = oyaml.safe_load(init_schema_file)
-        assert psm1.store[SCHEMA_KEY].pipeline_name == init_schema[SCHEMA_PIPELINE_NAME_KEY]
+        assert psm1.cfg[SCHEMA_KEY].pipeline_name == init_schema[SCHEMA_PIPELINE_NAME_KEY]
         ns2 = "namespace2"
         temp_schema_path = str(tmp_path / "schema.yaml")
         init_schema[SCHEMA_PIPELINE_NAME_KEY] = ns2
@@ -105,7 +105,7 @@ class TestPipestatManagerInstantiation:
                 schema_path=temp_schema_path,
             )
         # exp_msg = f"'{tmp_res_file}' is already used to report results for a different (not {ns2}) namespace: {psm1.schema.pipeline_name}"
-        exp_msg = f"'{tmp_res_file}' is already in use for 1 namespaces: {psm1.store[SCHEMA_KEY].pipeline_name} and multi_pipelines = False."
+        exp_msg = f"'{tmp_res_file}' is already in use for 1 namespaces: {psm1.cfg[SCHEMA_KEY].pipeline_name} and multi_pipelines = False."
         obs_msg = str(exc_ctx.value)
         assert obs_msg == exp_msg
 

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -473,8 +473,8 @@ class TestRetrieval:
                 list(val.values())[0]
             )
 
-    @pytest.mark.parametrize("backend", ["db"])
-    def test_get_records(
+    @pytest.mark.parametrize("backend", ["file", "db"])
+    def test_select_records_no_filter(
         self,
         config_file_path,
         results_file_path,
@@ -498,12 +498,12 @@ class TestRetrieval:
             for k, v in val_dict.items():
                 psm.report(record_identifier=k, values=v, force_overwrite=True)
 
-            results = psm.get_records()
-            assert results["records"][0] == list(val_dict.keys())[0]
-            assert results["count"] == len(list(val_dict.keys()))
-            results = psm.get_records(limit=1, offset=1)
-            assert results["records"][0] == list(val_dict.keys())[1]
-            assert results["count"] == 2
+            results = psm.select_records()
+
+            assert results["records"][0]["record_identifier"] == list(val_dict.keys())[0]
+            assert results["total_size"] == len(list(val_dict.keys()))
+            results = psm.select_records(limit=1)
+            assert len(results["records"]) == 1
 
     @pytest.mark.parametrize(
         ["rec_id", "res_id"],
@@ -1778,17 +1778,13 @@ class TestSelectRecords:
             result1 = psm.retrieve_one(record_identifier="sample1")
 
             assert len(result1["records"]) == 1
-            if backend != "db":
-                assert result1["records"][0]["record_identifier"] == "sample1"
-            else:
-                result1["records"][0].record_identifier == "sample1"
+
+            assert result1["records"][0]["record_identifier"] == "sample1"
 
             result2 = psm.retrieve_many(["sample1", "sample3", "sample5"])
             assert len(result2["records"]) == 3
-            if backend != "db":
-                assert result2["records"][2]["record_identifier"] == "sample5"
-            else:
-                assert result2["records"][2].record_identifier == "sample5"
+
+            assert result2["records"][2]["record_identifier"] == "sample5"
 
     @pytest.mark.parametrize("backend", ["file", "db"])
     def test_select_distinct(

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -87,14 +87,14 @@ class TestSplitClasses:
                 status = psm.get_status(record_identifier=rec_id)
                 assert status is None
                 # with pytest.raises(RecordNotFoundError):
-                #     psm.retrieve(record_identifier=rec_id)
+                #     psm.retrieve_one(record_identifier=rec_id)
             if backend == "db":
                 assert (
                     psm.retrieve_one(record_identifier=rec_id)["records"][0].get(val_name) is None
                 )
                 psm.remove(record_identifier=rec_id)
                 # with pytest.raises(RecordNotFoundError):
-                #     psm.retrieve(record_identifier=rec_id)
+                #     psm.retrieve_one(record_identifier=rec_id)
 
     @pytest.mark.parametrize(
         ["rec_id", "val"],
@@ -719,9 +719,9 @@ class TestRemoval:
                 record_identifier=rec_id, values={res_id: "something"}, force_overwrite=True
             )
             assert psm.remove(record_identifier=rec_id, result_identifier=res_id)
-            # if backend == "file":
-            #     with pytest.raises(RecordNotFoundError):
-            #         psm.retrieve(record_identifier=rec_id)
+            if backend == "file":
+                with pytest.raises(RecordNotFoundError):
+                    psm.retrieve_one(record_identifier=rec_id)
 
 
 class TestNoRecordID:

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -639,46 +639,91 @@ class TestRetrieval:
 
             for i in range(100):
                 r_id = "sample" + str(i)
-                val = {"md5sum": "hash" + str(i)}
+                val = {"md5sum": "hash" + str(i),
+                       "number_of_things": i*10,
+                       "switch_value": bool(i%2),
+                        "output_image": {
+                        "path": "path_to_"+str(i),
+                        "thumbnail_path": "thumbnail_path"+str(i),
+                        "title": "title_string"+str(i),},
+                }
+
+
                 psm.report(record_identifier=r_id, values=val, force_overwrite=True)
 
             # Gets one or many records
-            result4 = psm.retrieve_one(record_identifier="sample1")
-
-            result5 = psm.retrieve_many(["sample1", "sample3"])
+            # result4 = psm.retrieve_one(record_identifier="sample1")
+            #
+            # result5 = psm.retrieve_many(["sample1", "sample3"])
 
             # Gets everything, need to implement paging
             result6 = psm.select_records()
+            #
+            # # Attempt filtering with columns and filter conditions
+            # result11 = psm.backend.select_records(
+            #     columns=["name_of_something", "record_identifier", "md5sum"],
+            #     filter_conditions=[("record_identifier", "eq", "sample4")],
+            # )
+            #
+            # result12 = psm.backend.select_records(
+            #     columns=["name_of_something", "record_identifier", "md5sum"],
+            #     filter_conditions=[("record_identifier", "eq", "sample4")],
+            #     cursor=4,
+            # )
+            #
+            # result13 = psm.backend.select_records(
+            #     columns=["name_of_something", "record_identifier", "md5sum"],
+            #     limit=10,
+            # )
+            #
+            # next_cursor = result13["next_page_token"]
+            #
+            # result14 = psm.backend.select_records(
+            #     columns=["md5sum", "record_identifier"],
+            #     cursor=next_cursor,
+            #     limit=50,
+            # )
+            #
+            # result15 = psm.backend.select_records(
+            #     columns=["name_of_something", "record_identifier", "md5sum"],
+            #     cursor=95,
+            #     limit=100,
+            # )
+            #
+            #
+            # result16 = psm.backend.select_records(
+            #     columns=["name_of_something", "record_identifier", "md5sum", "number_of_things"],
+            #     filter_conditions=[("id", "ge", "0"),("id", "lt", "25") ],
+            #     limit=50,
+            # )
+            #
+            # result17 = psm.backend.select_records(
+            #     columns=["name_of_something", "record_identifier", "md5sum", "number_of_things"],
+            #     filter_conditions=[("id", "ge", "0"),("id", "lt", "25") ],
+            #     limit=50,
+            # )
+            # json_entry = '{"path": "path_to_39", "title": "title_string39", "thumbnail_path": "thumbnail_path39"}'
+            #
+            # result18 = psm.backend.select_records(
+            #     #columns=["name_of_something", "record_identifier", "md5sum", "number_of_things"],
+            #     json_filter_conditions=[("output_image", "ge", json_entry)],
+            #     limit=50,
+            # )
 
-            # Attempt filtering with columns and filter conditions
-            result11 = psm.backend.select_records(
-                columns=["name_of_something", "record_identifier", "md5sum"],
-                filter_conditions=[("record_identifier", "eq", "sample4")],
-            )
+            # # THis should not return any results
+            # tuple_example = ("number_of_things", "eq", 390)
+            # result19 = psm.backend.select_records(
+            #     #columns=["name_of_something", "record_identifier", "md5sum", "number_of_things"],
+            #     filter_conditions=[("output_image", "eq", tuple_example)],
+            #     limit=50,
+            # )
 
-            result12 = psm.backend.select_records(
-                columns=["name_of_something", "record_identifier", "md5sum"],
-                filter_conditions=[("record_identifier", "eq", "sample4")],
-                cursor=4,
-            )
-
-            result13 = psm.backend.select_records(
-                columns=["name_of_something", "record_identifier", "md5sum"],
-                limit=10,
-            )
-
-            next_cursor = result13["next_page_token"]
-
-            result14 = psm.backend.select_records(
-                columns=["name_of_something", "record_identifier", "md5sum"],
-                cursor=next_cursor,
-                limit=10,
-            )
-
-            result15 = psm.backend.select_records(
-                columns=["name_of_something", "record_identifier", "md5sum"],
-                cursor=95,
-                limit=100,
+            # This works for filtering based on items within the JSONB!
+            json_entry = '{"path": "path_to_39"}'
+            result19 = psm.backend.select_records(
+                #columns=["name_of_something", "record_identifier", "md5sum", "number_of_things"],
+                json_filter_conditions=[("output_image", "eq", json_entry)],
+                limit=50,
             )
 
             print("Done")

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -1779,7 +1779,7 @@ class TestSelectRecords:
             assert len(result2["records"]) == 3
             assert result2["records"][2].record_identifier == "sample5"
 
-    @pytest.mark.skip("not implemented")
+    #@pytest.mark.skip("not implemented")
     @pytest.mark.parametrize("backend", ["file", "db"])
     def test_select_distinct(
         self,
@@ -1799,7 +1799,7 @@ class TestSelectRecords:
             args.update(backend_data)
             psm = SamplePipestatManager(**args)
 
-            for i in range(6):
+            for i in range(10):
                 r_id = "sample" + str(i)
                 val = {
                     "md5sum": "hash" + str(i),
@@ -1819,8 +1819,24 @@ class TestSelectRecords:
 
                 psm.report(record_identifier=r_id, values=val, force_overwrite=True)
 
+            for i in range(0,10,2):
+                r_id = "sample" + str(i)
+                val = {
+                    "md5sum": "hash0",
+                    "number_of_things": 500,
+                }
+                #Overwrite a couple of results such that they are not all unique
+                psm.report(record_identifier=r_id, values=val, force_overwrite=True)
+
+            val = {
+                "number_of_things": 900,
+            }
+            psm.report(record_identifier="sample2", values=val, force_overwrite=True)
             # Gets one or many records
-            result1 = psm.select_distinct(columns=["md5sum"])
+            result1 = psm.select_distinct(columns=["md5sum", "number_of_things", "record_identifier"])
+            result2 = psm.select_distinct(columns=["md5sum", "number_of_things"])
+            result3 = psm.select_distinct(columns=["md5sum"])
+            print(result1)
 
             # assert len(result1["records"]) == 1
             # assert result1["records"][0].record_identifier == "sample1"

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -1363,7 +1363,7 @@ class TestTimeStamp:
 
 
 class TestSelectRecords:
-    @pytest.mark.parametrize("backend", ["file"])
+    @pytest.mark.parametrize("backend", ["file", "db"])
     def test_select_records_basic(
         self,
         config_file_path,

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -1363,7 +1363,7 @@ class TestTimeStamp:
 
 
 class TestSelectRecords:
-    @pytest.mark.parametrize("backend", ["file","db"])
+    @pytest.mark.parametrize("backend", ["file"])
     def test_select_records_basic(
         self,
         config_file_path,

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -1382,11 +1382,12 @@ class TestSelectRecords:
             args.update(backend_data)
             psm = SamplePipestatManager(**args)
 
-            for i in range(10):
+            for i in range(12):
                 r_id = "sample" + str(i)
                 val = {
                     "md5sum": "hash" + str(i),
                     "number_of_things": i * 10,
+                    "percentage_of_things": i % 2,
                     "switch_value": bool(i % 2),
                     "output_image": {
                         "path": "path_to_" + str(i),
@@ -1412,34 +1413,41 @@ class TestSelectRecords:
                 ],
             )
 
-            assert len(result1["records"]) == 2
-            assert result1["records"][0].record_identifier == "sample8"
+            assert len(result1["records"]) == 4
 
             result1 = psm.select_records(
                 filter_conditions=[
                     {
                         "key": "number_of_things",
+                        "operator": "ge",
+                        "value": 80,
+                    },
+                    {
+                        "key": "percentage_of_things",
                         "operator": "eq",
-                        "value": 80,
+                        "value": 1,
                     },
                 ],
             )
 
-            assert len(result1["records"]) == 1
-            assert result1["records"][0].record_identifier == "sample8"
+            assert len(result1["records"]) == 2
 
             result1 = psm.select_records(
                 filter_conditions=[
                     {
                         "key": "number_of_things",
-                        "operator": "lt",
+                        "operator": "ge",
                         "value": 80,
                     },
+                    {
+                        "key": "percentage_of_things",
+                        "operator": "eq",
+                        "value": 1,
+                    },
                 ],
+                bool_operator="OR",
             )
-
             assert len(result1["records"]) == 8
-            assert result1["records"][0].record_identifier == "sample0"
 
     @pytest.mark.parametrize("backend", ["db"])
     def test_select_records_bad_op(
@@ -1610,7 +1618,6 @@ class TestSelectRecords:
             result2 = psm.retrieve_many(["sample1", "sample3", "sample5"])
             assert len(result2["records"]) == 3
             assert result2["records"][2].record_identifier == "sample5"
-
 
     @pytest.mark.skip("not implemented")
     @pytest.mark.parametrize("backend", ["file", "db"])

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -1610,3 +1610,54 @@ class TestSelectRecords:
             result2 = psm.retrieve_many(["sample1", "sample3", "sample5"])
             assert len(result2["records"]) == 3
             assert result2["records"][2].record_identifier == "sample5"
+
+
+    @pytest.mark.skip("not implemented")
+    @pytest.mark.parametrize("backend", ["file", "db"])
+    def test_select_distinct(
+        self,
+        config_file_path,
+        results_file_path,
+        recursive_schema_file_path,
+        backend,
+    ):
+        with NamedTemporaryFile() as f, ContextManagerDBTesting(DB_URL):
+            results_file_path = f.name
+            args = dict(schema_path=recursive_schema_file_path, database_only=False)
+            backend_data = (
+                {"config_file": config_file_path}
+                if backend == "db"
+                else {"results_file_path": results_file_path}
+            )
+            args.update(backend_data)
+            psm = SamplePipestatManager(**args)
+
+            for i in range(6):
+                r_id = "sample" + str(i)
+                val = {
+                    "md5sum": "hash" + str(i),
+                    "number_of_things": i * 10,
+                    "switch_value": bool(i % 2),
+                    "output_image": {
+                        "path": "path_to_" + str(i),
+                        "thumbnail_path": "thumbnail_path" + str(i),
+                        "title": "title_string" + str(i),
+                    },
+                    "output_file_in_object_nested": {
+                        "prop1": {
+                            "prop2": i,
+                        },
+                    },
+                }
+
+                psm.report(record_identifier=r_id, values=val, force_overwrite=True)
+
+            # Gets one or many records
+            result1 = psm.select_distinct(columns=["md5sum"])
+
+            # assert len(result1["records"]) == 1
+            # assert result1["records"][0].record_identifier == "sample1"
+            #
+            # result2 = psm.retrieve_many(["sample1", "sample3", "sample5"])
+            # assert len(result2["records"]) == 3
+            # assert result2["records"][2].record_identifier == "sample5"

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -863,8 +863,8 @@ def test_manager_has_correct_status_schema_and_status_schema_source(
     schema_file_path, exp_status_schema, exp_status_schema_path, backend_data
 ):
     psm = SamplePipestatManager(schema_path=schema_file_path, **backend_data)
-    assert psm.store[STATUS_SCHEMA_KEY] == exp_status_schema
-    assert psm.store[STATUS_SCHEMA_SOURCE_KEY] == exp_status_schema_path
+    assert psm.cfg[STATUS_SCHEMA_KEY] == exp_status_schema
+    assert psm.cfg[STATUS_SCHEMA_SOURCE_KEY] == exp_status_schema_path
 
 
 class TestPipestatBoss:

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -472,68 +472,6 @@ class TestRetrieval:
                 list(val.values())[0]
             )
 
-    @pytest.mark.parametrize("backend", ["file", "db"])
-    def test_retrieve_multiple(
-        self,
-        config_file_path,
-        results_file_path,
-        schema_file_path,
-        backend,
-    ):
-        values_sample = [
-            {"sample1": {"name_of_something": "string 1"}},
-            {"sample1": {"number_of_things": 1}},
-            {"sample2": {"name_of_something": "string 2"}},
-            {"sample2": {"number_of_things": 20}},
-            {"sample3": {"name_of_something": "string 3"}},
-            {"sample3": {"number_of_things": 300}},
-        ]
-
-        with NamedTemporaryFile() as f, ContextManagerDBTesting(DB_URL):
-            results_file_path = f.name
-            args = dict(schema_path=schema_file_path, database_only=False)
-            backend_data = (
-                {"config_file": config_file_path}
-                if backend == "db"
-                else {"results_file_path": results_file_path}
-            )
-            args.update(backend_data)
-            psm = SamplePipestatManager(**args)
-
-            for i in values_sample:
-                for k, v in i.items():
-                    psm.report(record_identifier=k, values=v, force_overwrite=True)
-
-            # Test singular list works as expected
-            r_id = list(values_sample[0].keys())[0]
-            res_id = list(list(values_sample[0].values())[0].keys())[0]
-            results = psm.retrieve(record_identifier=[r_id], result_identifier=[res_id])
-            assert results == list(list(values_sample[0].values())[0].values())[0]
-
-            # Use list of results
-            r_ids = ["sample1", "sample2"]
-            res_id = ["md5sum", "number_of_things"]
-            # res_id = list(list(values_sample[0].values())[0].keys())[0]
-            results = psm.retrieve(record_identifier=r_ids, result_identifier=res_id)
-            assert r_ids[0] == list(results["records"][0].keys())[0]
-            assert (
-                list(list(values_sample[3].values())[0].values())[0]
-                == list(results["records"][1].values())[0]["number_of_things"]
-            )
-
-            # Test combinations of empty list for either record or result identifiers.
-            results = psm.retrieve(record_identifier=r_ids, result_identifier=[])
-            assert len(results["result_identifiers"]) == 9
-            assert len(results["records"]) == 2
-
-            results = psm.retrieve(record_identifier=[], result_identifier=[])
-            assert len(results["result_identifiers"]) == 9
-            assert len(results["records"]) == 3
-
-            results = psm.retrieve(record_identifier=[], result_identifier=res_id)
-            assert "md5sum" in results["result_identifiers"]
-            assert len(results["records"]) == 3
-
     @pytest.mark.parametrize("backend", ["db"])
     def test_get_records(
         self,
@@ -643,8 +581,16 @@ class TestRemoval:
             else:
                 col_name = list(vals[0].keys())[0]
                 value = list(vals[0].values())[0]
-                result = psm.backend.select(filter_conditions=[(col_name, "eq", value)])
-                assert len(result) == 0
+                result = psm.select_records(
+                    filter_conditions=[
+                        {
+                            "key": col_name,
+                            "operator": "eq",
+                            "value": value,
+                        }
+                    ]
+                )
+                assert len(result["records"]) == 0
 
     @pytest.mark.parametrize("rec_id", ["sample1", "sample2"])
     @pytest.mark.parametrize("backend", ["file", "db"])
@@ -673,8 +619,16 @@ class TestRemoval:
             else:
                 col_name = list(vals[0].keys())[0]
                 value = list(vals[0].values())[0]
-                result = psm.backend.select(filter_conditions=[(col_name, "eq", value)])
-                assert len(result) == 0
+                result = psm.select_records(
+                    filter_conditions=[
+                        {
+                            "key": col_name,
+                            "operator": "eq",
+                            "value": value,
+                        }
+                    ]
+                )
+                assert len(result["records"]) == 0
 
     @pytest.mark.parametrize(
         ["rec_id", "res_id"], [("sample2", "nonexistent"), ("sample2", "bogus")]
@@ -794,7 +748,15 @@ class TestNoRecordID:
                 )
             if backend == "db":
                 val_name = list(val.keys())[0]
-                assert psm.backend.select(filter_conditions=[(val_name, "eq", val[val_name])])
+                assert psm.select_records(
+                    filter_conditions=[
+                        {
+                            "key": val_name,
+                            "operator": "eq",
+                            "value": val[val_name],
+                        }
+                    ]
+                )
 
     @pytest.mark.parametrize(
         "val",
@@ -1440,7 +1402,7 @@ class TestSelectRecords:
 
                 psm.report(record_identifier=r_id, values=val, force_overwrite=True)
 
-            result1 = psm.backend.select_records(
+            result1 = psm.select_records(
                 filter_conditions=[
                     {
                         "key": "number_of_things",
@@ -1453,7 +1415,7 @@ class TestSelectRecords:
             assert len(result1["records"]) == 2
             assert result1["records"][0].record_identifier == "sample8"
 
-            result1 = psm.backend.select_records(
+            result1 = psm.select_records(
                 filter_conditions=[
                     {
                         "key": "number_of_things",
@@ -1466,7 +1428,7 @@ class TestSelectRecords:
             assert len(result1["records"]) == 1
             assert result1["records"][0].record_identifier == "sample8"
 
-            result1 = psm.backend.select_records(
+            result1 = psm.select_records(
                 filter_conditions=[
                     {
                         "key": "number_of_things",
@@ -1520,7 +1482,7 @@ class TestSelectRecords:
 
             with pytest.raises(ValueError):
                 # Unknown operator raises error
-                result20 = psm.backend.select_records(
+                result20 = psm.select_records(
                     # columns=["md5sum"],
                     filter_conditions=[
                         {
@@ -1535,7 +1497,7 @@ class TestSelectRecords:
 
             with pytest.raises(ValueError):
                 # bad key raises error
-                result20 = psm.backend.select_records(
+                result20 = psm.select_records(
                     filter_conditions=[
                         {
                             "_garbled_key": "number_of_things",
@@ -1588,8 +1550,7 @@ class TestSelectRecords:
 
             with pytest.raises(ValueError):
                 # Column doesn't exist raises error
-                result20 = psm.backend.select_records(
-                    # columns=["md5sum"],
+                result20 = psm.select_records(
                     filter_conditions=[
                         {
                             "key": "not_number_of_things",

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -1,5 +1,6 @@
 import os.path
 import datetime
+import time
 from collections.abc import Mapping
 
 import pytest
@@ -1279,7 +1280,7 @@ class TestTimeStamp:
             ("sample1", {"name_of_something": "test_name"}),
         ],
     )
-    @pytest.mark.parametrize("backend", ["db"])
+    @pytest.mark.parametrize("backend", ["file", "db"])
     def test_basic_time_stamp(
         self,
         rec_id,
@@ -1309,6 +1310,9 @@ class TestTimeStamp:
             assert created == modified
             # Report new
             val = {"number_of_things": 1}
+            time.sleep(
+                1
+            )  # The filebackend is so fast that the updated time will equal the created time
             psm.report(record_identifier="sample1", values=val, force_overwrite=True)
             # CHECK MODIFY TIME DIFFERS FROM CREATED TIME
             created = psm.retrieve(record_identifier=rec_id, result_identifier=CREATED_TIME)

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -487,11 +487,12 @@ class TestRetrieval:
             args.update(backend_data)
             psm = SamplePipestatManager(**args)
             psm.report(record_identifier=rec_id, values=val, force_overwrite=True)
-            retrieved_val = psm[rec_id]
-            # Test Retrieve Basic
-            assert str(retrieved_val[str(list(retrieved_val.keys())[0])]) == str(
-                list(val.values())[0]
-            )
+
+            val_name = list(val.keys())[0]
+            retrieved_val = psm[rec_id]["records"][0][val_name]
+            value = list(val.values())[0]
+
+            assert retrieved_val == value
 
     @pytest.mark.parametrize("backend", ["file", "db"])
     def test_select_records_no_filter(

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -1548,7 +1548,7 @@ class TestSelectRecords:
             print(result1)
             assert len(result1["records"]) == 2
 
-    @pytest.mark.parametrize("backend", ["db"])
+    @pytest.mark.parametrize("backend", ["file", "db"])
     def test_select_records_bad_op(
         self,
         config_file_path,
@@ -1655,19 +1655,20 @@ class TestSelectRecords:
 
                 psm.report(record_identifier=r_id, values=val, force_overwrite=True)
 
-            with pytest.raises(ValueError):
-                # Column doesn't exist raises error
-                result20 = psm.select_records(
-                    filter_conditions=[
-                        {
-                            "key": "not_number_of_things",
-                            "operator": "eq",
-                            "value": 0,
-                        },
-                    ],
-                    limit=50,
-                    bool_operator="or",
-                )
+            if backend == "db":
+                with pytest.raises(ValueError):
+                    # Column doesn't exist raises error
+                    result20 = psm.select_records(
+                        filter_conditions=[
+                            {
+                                "key": "not_number_of_things",
+                                "operator": "eq",
+                                "value": 0,
+                            },
+                        ],
+                        limit=50,
+                        bool_operator="or",
+                    )
 
     @pytest.mark.parametrize("backend", ["file", "db"])
     def test_select_records_complex_result(
@@ -1730,7 +1731,7 @@ class TestSelectRecords:
 
             print(result)
 
-    @pytest.mark.parametrize("backend", ["db"])
+    @pytest.mark.parametrize("backend", ["file", "db"])
     def test_select_records_retrieve_one_many(
         self,
         config_file_path,
@@ -1773,11 +1774,17 @@ class TestSelectRecords:
             result1 = psm.retrieve_one(record_identifier="sample1")
 
             assert len(result1["records"]) == 1
-            assert result1["records"][0].record_identifier == "sample1"
+            if backend != "db":
+                assert result1["records"][0]["record_identifier"] == "sample1"
+            else:
+                result1["records"][0].record_identifier == "sample1"
 
             result2 = psm.retrieve_many(["sample1", "sample3", "sample5"])
             assert len(result2["records"]) == 3
-            assert result2["records"][2].record_identifier == "sample5"
+            if backend != "db":
+                assert result2["records"][2]["record_identifier"] == "sample5"
+            else:
+                assert result2["records"][2].record_identifier == "sample5"
 
     @pytest.mark.parametrize("backend", ["file", "db"])
     def test_select_distinct(

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -863,8 +863,8 @@ def test_manager_has_correct_status_schema_and_status_schema_source(
     schema_file_path, exp_status_schema, exp_status_schema_path, backend_data
 ):
     psm = SamplePipestatManager(schema_path=schema_file_path, **backend_data)
-    assert psm.status_schema == exp_status_schema
-    assert psm.status_schema_source == exp_status_schema_path
+    assert psm.store[STATUS_SCHEMA_KEY] == exp_status_schema
+    assert psm.store[STATUS_SCHEMA_SOURCE_KEY] == exp_status_schema_path
 
 
 class TestPipestatBoss:

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -1779,7 +1779,6 @@ class TestSelectRecords:
             assert len(result2["records"]) == 3
             assert result2["records"][2].record_identifier == "sample5"
 
-    #@pytest.mark.skip("not implemented")
     @pytest.mark.parametrize("backend", ["file", "db"])
     def test_select_distinct(
         self,
@@ -1819,13 +1818,13 @@ class TestSelectRecords:
 
                 psm.report(record_identifier=r_id, values=val, force_overwrite=True)
 
-            for i in range(0,10,2):
+            for i in range(0, 10, 2):
                 r_id = "sample" + str(i)
                 val = {
                     "md5sum": "hash0",
                     "number_of_things": 500,
                 }
-                #Overwrite a couple of results such that they are not all unique
+                # Overwrite a couple of results such that they are not all unique
                 psm.report(record_identifier=r_id, values=val, force_overwrite=True)
 
             val = {
@@ -1833,14 +1832,11 @@ class TestSelectRecords:
             }
             psm.report(record_identifier="sample2", values=val, force_overwrite=True)
             # Gets one or many records
-            result1 = psm.select_distinct(columns=["md5sum", "number_of_things", "record_identifier"])
+            result1 = psm.select_distinct(
+                columns=["md5sum", "number_of_things", "record_identifier"]
+            )
+            assert len(result1) == 10
             result2 = psm.select_distinct(columns=["md5sum", "number_of_things"])
+            assert len(result2) == 7
             result3 = psm.select_distinct(columns=["md5sum"])
-            print(result1)
-
-            # assert len(result1["records"]) == 1
-            # assert result1["records"][0].record_identifier == "sample1"
-            #
-            # result2 = psm.retrieve_many(["sample1", "sample3", "sample5"])
-            # assert len(result2["records"]) == 3
-            # assert result2["records"][2].record_identifier == "sample5"
+            assert len(result3) == 6

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -639,22 +639,28 @@ class TestRetrieval:
 
             for i in range(100):
                 r_id = "sample" + str(i)
-                val = {"md5sum": "hash" + str(i),
-                       "number_of_things": i*10,
-                       "switch_value": bool(i%2),
-                        "output_image": {
-                        "path": "path_to_"+str(i),
-                        "thumbnail_path": "thumbnail_path"+str(i),
-                        "title": "title_string"+str(i),},
+                val = {
+                    "md5sum": "hash" + str(i),
+                    "number_of_things": i * 10,
+                    "switch_value": bool(i % 2),
+                    "output_image": {
+                        "path": "path_to_" + str(i),
+                        "thumbnail_path": "thumbnail_path" + str(i),
+                        "title": "title_string" + str(i),
+                    },
+                    "output_file_in_object": {
+                        "prop1": {
+                            "prop2": i,
+                        },
+                    },
                 }
-
 
                 psm.report(record_identifier=r_id, values=val, force_overwrite=True)
 
             # # Gets one or many records
             # result4 = psm.retrieve_one(record_identifier="sample1")
             #
-            result5 = psm.retrieve_many(["sample1", "sample3"])
+            # result5 = psm.retrieve_many(["sample1", "sample3"])
             #
             # # Gets everything, need to implement paging
             # result6 = psm.select_records()
@@ -719,20 +725,40 @@ class TestRetrieval:
             # )
 
             # This works for filtering based on items within the JSONB!
-            #json_entry = '"path"'
+            # json_entry = '"path"'
             json_entry2 = '{"title": "title_string25"}'
             # json_entry = '{"path": 26}'
-            result19 = psm.backend.select_records(
-                #columns=["md5sum"],
-                #filter_conditions=[("id", "ge", "0"),("id", "lt", "50")],
-                json_filter_conditions=[("output_image", "eq", json_entry2)],
-                limit=50,
-            )
+            # result19 = psm.backend.select_records(
+            #     #columns=["md5sum"],
+            #     #filter_conditions=[("id", "ge", "0"),("id", "lt", "50")],
+            #     json_filter_conditions=[("output_image", "eq", json_entry2)],
+            #     limit=50,
+            # )
 
+            result20 = psm.backend.select_records(
+                # columns=["md5sum"],
+                filter_conditions=[
+                    {
+                        "key": ["output_file_in_object", "prop1", "prop2"],
+                        "operator": "in",
+                        "value": [5, 20],
+                    },
+                    {
+                        "key": ["output_file_in_object", "prop1", "prop2"],
+                        "operator": "in",
+                        "value": [7, 21],
+                    },
+                ],
+                limit=50,
+                bool_operator="or",
+            )
             # result20 = psm.backend.select_records(
-            #     columns=["md5sum"],
-            #     filter_conditions=[("id", "eq", "1"),("id", "eq", "50")],
-            #     #json_filter_conditions=[("output_image", "eq", json_entry)],
+            #     # columns=["md5sum"],
+            #     filter_conditions=[{
+            #         "key": "number_of_things",
+            #         "operator": "ge",
+            #         "value": 0,
+            #     }],
             #     limit=50,
             #     bool_operator="or",
             # )

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -1363,7 +1363,7 @@ class TestTimeStamp:
 
 
 class TestSelectRecords:
-    @pytest.mark.parametrize("backend", ["db"])
+    @pytest.mark.parametrize("backend", ["file","db"])
     def test_select_records_basic(
         self,
         config_file_path,

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -651,13 +651,13 @@ class TestRetrieval:
 
                 psm.report(record_identifier=r_id, values=val, force_overwrite=True)
 
-            # Gets one or many records
-            result4 = psm.retrieve_one(record_identifier="sample1")
-
-            result5 = psm.retrieve_many(["sample1", "sample3"])
-
-            # Gets everything, need to implement paging
-            result6 = psm.select_records()
+            # # Gets one or many records
+            # result4 = psm.retrieve_one(record_identifier="sample1")
+            #
+            # result5 = psm.retrieve_many(["sample1", "sample3"])
+            #
+            # # Gets everything, need to implement paging
+            # result6 = psm.select_records()
             #
             # # Attempt filtering with columns and filter conditions
             # result11 = psm.backend.select_records(
@@ -722,12 +722,30 @@ class TestRetrieval:
             json_entry = '{"path": "path_to_39"}'
             json_entry2 = '{"title": "title_string25"}'
             #json_entry = '{"path": 26}'
-            result19 = psm.backend.select_records(
-                #columns=["md5sum"],
-                filter_conditions=[("id", "ge", "0"),("id", "lt", "50")],
-                json_filter_conditions=[("output_image", "eq", json_entry)],
+            # result19 = psm.backend.select_records(
+            #     columns=["md5sum"],
+            #     filter_conditions=[("id", "ge", "0"),("id", "lt", "50")],
+            #     #json_filter_conditions=[("output_image", "eq", json_entry)],
+            #     limit=50,
+            # )
+
+            result20 = psm.backend.select_records(
+                columns=["md5sum"],
+                filter_conditions=[("id", "eq", "1"),("id", "eq", "50")],
+                #json_filter_conditions=[("output_image", "eq", json_entry)],
                 limit=50,
+                bool_operator="or",
             )
+
+            # bool_operator: Optional[str] = "AND",
+
+            # result20 = psm.backend.select_records(
+            #     #columns=["md5sum"],
+            #     filter_conditions=[("id", "ge", "0"),("id", "lt", "50")],
+            #     #json_filter_conditions=[("output_image", "eq", json_entry)],
+            #     limit=50,
+            #     bool_operator = "OR",
+            # )
 
             print("Done")
 

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -1449,6 +1449,105 @@ class TestSelectRecords:
             )
             assert len(result1["records"]) == 8
 
+    @pytest.mark.parametrize("backend", ["file", "db"])
+    def test_select_records_columns(
+        self,
+        config_file_path,
+        results_file_path,
+        recursive_schema_file_path,
+        backend,
+    ):
+        with NamedTemporaryFile() as f, ContextManagerDBTesting(DB_URL):
+            results_file_path = f.name
+            args = dict(schema_path=recursive_schema_file_path, database_only=False)
+            backend_data = (
+                {"config_file": config_file_path}
+                if backend == "db"
+                else {"results_file_path": results_file_path}
+            )
+            args.update(backend_data)
+            psm = SamplePipestatManager(**args)
+
+            for i in range(2):
+                r_id = "sample" + str(i)
+                val = {
+                    "md5sum": "hash" + str(i),
+                    "number_of_things": i * 10,
+                    "percentage_of_things": i % 2,
+                    "switch_value": bool(i % 2),
+                    "output_image": {
+                        "path": "path_to_" + str(i),
+                        "thumbnail_path": "thumbnail_path" + str(i),
+                        "title": "title_string" + str(i),
+                    },
+                    "output_file_in_object_nested": {
+                        "prop1": {
+                            "prop2": i,
+                        },
+                    },
+                }
+
+                psm.report(record_identifier=r_id, values=val, force_overwrite=True)
+
+            result1 = psm.select_records(
+                filter_conditions=[
+                    {
+                        "key": "number_of_things",
+                        "operator": "ge",
+                        "value": 0,
+                    },
+                ],
+                columns=["number_of_things"],
+            )
+
+            print(result1)
+            assert len(result1["records"][0]) == 2
+
+    @pytest.mark.parametrize("backend", ["file", "db"])
+    def test_select_no_filter(
+        self,
+        config_file_path,
+        results_file_path,
+        recursive_schema_file_path,
+        backend,
+    ):
+        with NamedTemporaryFile() as f, ContextManagerDBTesting(DB_URL):
+            results_file_path = f.name
+            args = dict(schema_path=recursive_schema_file_path, database_only=False)
+            backend_data = (
+                {"config_file": config_file_path}
+                if backend == "db"
+                else {"results_file_path": results_file_path}
+            )
+            args.update(backend_data)
+            psm = SamplePipestatManager(**args)
+
+            for i in range(2):
+                r_id = "sample" + str(i)
+                val = {
+                    "md5sum": "hash" + str(i),
+                    "number_of_things": i * 10,
+                    "percentage_of_things": i % 2,
+                    "switch_value": bool(i % 2),
+                    "output_image": {
+                        "path": "path_to_" + str(i),
+                        "thumbnail_path": "thumbnail_path" + str(i),
+                        "title": "title_string" + str(i),
+                    },
+                    "output_file_in_object_nested": {
+                        "prop1": {
+                            "prop2": i,
+                        },
+                    },
+                }
+
+                psm.report(record_identifier=r_id, values=val, force_overwrite=True)
+
+            result1 = psm.select_records()
+
+            print(result1)
+            assert len(result1["records"]) == 2
+
     @pytest.mark.parametrize("backend", ["db"])
     def test_select_records_bad_op(
         self,

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -654,7 +654,7 @@ class TestRetrieval:
             # # Gets one or many records
             # result4 = psm.retrieve_one(record_identifier="sample1")
             #
-            # result5 = psm.retrieve_many(["sample1", "sample3"])
+            result5 = psm.retrieve_many(["sample1", "sample3"])
             #
             # # Gets everything, need to implement paging
             # result6 = psm.select_records()
@@ -719,23 +719,23 @@ class TestRetrieval:
             # )
 
             # This works for filtering based on items within the JSONB!
-            json_entry = '{"path": "path_to_39"}'
+            #json_entry = '"path"'
             json_entry2 = '{"title": "title_string25"}'
-            #json_entry = '{"path": 26}'
-            # result19 = psm.backend.select_records(
+            # json_entry = '{"path": 26}'
+            result19 = psm.backend.select_records(
+                #columns=["md5sum"],
+                #filter_conditions=[("id", "ge", "0"),("id", "lt", "50")],
+                json_filter_conditions=[("output_image", "eq", json_entry2)],
+                limit=50,
+            )
+
+            # result20 = psm.backend.select_records(
             #     columns=["md5sum"],
-            #     filter_conditions=[("id", "ge", "0"),("id", "lt", "50")],
+            #     filter_conditions=[("id", "eq", "1"),("id", "eq", "50")],
             #     #json_filter_conditions=[("output_image", "eq", json_entry)],
             #     limit=50,
+            #     bool_operator="or",
             # )
-
-            result20 = psm.backend.select_records(
-                columns=["md5sum"],
-                filter_conditions=[("id", "eq", "1"),("id", "eq", "50")],
-                #json_filter_conditions=[("output_image", "eq", json_entry)],
-                limit=50,
-                bool_operator="or",
-            )
 
             # bool_operator: Optional[str] = "AND",
 

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -652,9 +652,9 @@ class TestRetrieval:
                 psm.report(record_identifier=r_id, values=val, force_overwrite=True)
 
             # Gets one or many records
-            # result4 = psm.retrieve_one(record_identifier="sample1")
-            #
-            # result5 = psm.retrieve_many(["sample1", "sample3"])
+            result4 = psm.retrieve_one(record_identifier="sample1")
+
+            result5 = psm.retrieve_many(["sample1", "sample3"])
 
             # Gets everything, need to implement paging
             result6 = psm.select_records()
@@ -720,8 +720,11 @@ class TestRetrieval:
 
             # This works for filtering based on items within the JSONB!
             json_entry = '{"path": "path_to_39"}'
+            json_entry2 = '{"title": "title_string25"}'
+            #json_entry = '{"path": 26}'
             result19 = psm.backend.select_records(
-                #columns=["name_of_something", "record_identifier", "md5sum", "number_of_things"],
+                #columns=["md5sum"],
+                filter_conditions=[("id", "ge", "0"),("id", "lt", "50")],
                 json_filter_conditions=[("output_image", "eq", json_entry)],
                 limit=50,
             )

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -78,7 +78,9 @@ class TestSplitClasses:
             psm.set_status(status_identifier="running", record_identifier=rec_id)
             status = psm.get_status(record_identifier=rec_id)
             assert status == "running"
-            assert psm.retrieve_one(record_identifier=rec_id)['records'][0][val_name] == val[val_name]
+            assert (
+                psm.retrieve_one(record_identifier=rec_id)["records"][0][val_name] == val[val_name]
+            )
             psm.remove(record_identifier=rec_id, result_identifier=val_name)
             if backend == "file":
                 psm.clear_status(record_identifier=rec_id)
@@ -126,13 +128,18 @@ class TestSplitClasses:
             psm.set_status(status_identifier="running", record_identifier=rec_id)
             status = psm.get_status(record_identifier=rec_id)
             assert status == "running"
-            assert psm.retrieve_one(record_identifier=rec_id)['records'][0][val_name] == val[val_name]
+            assert (
+                psm.retrieve_one(record_identifier=rec_id)["records"][0][val_name] == val[val_name]
+            )
             psm.remove(record_identifier=rec_id, result_identifier=val_name)
             if backend == "file":
                 psm.clear_status(record_identifier=rec_id)
                 status = psm.get_status(record_identifier=rec_id)
                 assert status is None
-                assert psm.retrieve_one(record_identifier=rec_id)['records'][0].get(val_name,None) == None
+                assert (
+                    psm.retrieve_one(record_identifier=rec_id)["records"][0].get(val_name, None)
+                    == None
+                )
                 # with pytest.raises(RecordNotFoundError):
                 #     psm.retrieve_one(record_identifier=rec_id)
             if backend == "db":
@@ -311,7 +318,10 @@ class TestReporting:
                 if backend == "file":
                     assert_is_in_files(results_file_path, str(list(val.values())[0]))
             if backend == "db":
-                assert psm.retrieve_one(record_identifier=rec_id)['records'][0][list(val.keys())[0]] == val[list(val.keys())[0]]
+                assert (
+                    psm.retrieve_one(record_identifier=rec_id)["records"][0][list(val.keys())[0]]
+                    == val[list(val.keys())[0]]
+                )
 
     @pytest.mark.parametrize(
         ["rec_id", "val", "success"],
@@ -435,14 +445,15 @@ class TestRetrieval:
             # retrieved_val = psm.retrieve(
             #     record_identifier=rec_id, result_identifier=list(val.keys())[0]
             # )
-            retrieved_val = psm.select_records(filter_conditions=[
-                        {
-                            "key": "record_identifier",
-                            "operator": "eq",
-                            "value": rec_id,
-                        },
-                    ],
-                columns=[list(val.keys())[0]]
+            retrieved_val = psm.select_records(
+                filter_conditions=[
+                    {
+                        "key": "record_identifier",
+                        "operator": "eq",
+                        "value": rec_id,
+                    },
+                ],
+                columns=[list(val.keys())[0]],
             )["records"][0]
             # Test Retrieve Basic
             assert str(list(val.keys())[0]) in list(retrieved_val.keys())
@@ -790,14 +801,15 @@ class TestNoRecordID:
             args.update(backend_data)
             psm = SamplePipestatManager(**args)
             psm.report(record_identifier="constant_record_id", values=val, force_overwrite=True)
-            retrieved_val = psm.select_records(filter_conditions=[
-                        {
-                            "key": "record_identifier",
-                            "operator": "eq",
-                            "value": "constant_record_id",
-                        },
-                    ],
-                columns=[list(val.keys())[0]]
+            retrieved_val = psm.select_records(
+                filter_conditions=[
+                    {
+                        "key": "record_identifier",
+                        "operator": "eq",
+                        "value": "constant_record_id",
+                    },
+                ],
+                columns=[list(val.keys())[0]],
             )["records"][0]
             assert str(list(val.keys())[0]) in list(retrieved_val.keys())
 

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -204,13 +204,13 @@ class TestReporting:
     )
     @pytest.mark.parametrize("backend", ["file", "db"])
     def test_report_setitem(
-            self,
-            rec_id,
-            val,
-            config_file_path,
-            schema_file_path,
-            results_file_path,
-            backend,
+        self,
+        rec_id,
+        val,
+        config_file_path,
+        schema_file_path,
+        results_file_path,
+        backend,
     ):
         with NamedTemporaryFile() as f, ContextManagerDBTesting(DB_URL):
             results_file_path = f.name
@@ -222,7 +222,7 @@ class TestReporting:
             )
             args.update(backend_data)
             psm = SamplePipestatManager(**args)
-            #psm.report(record_identifier=rec_id, values=val, force_overwrite=True)
+            # psm.report(record_identifier=rec_id, values=val, force_overwrite=True)
             psm[rec_id] = val
             if backend == "file":
                 print(psm.backend._data[STANDARD_TEST_PIPE_ID])
@@ -230,8 +230,8 @@ class TestReporting:
                 assert rec_id in psm.backend._data[STANDARD_TEST_PIPE_ID][PROJECT_SAMPLE_LEVEL]
                 print("Test if", list(val.keys())[0], " is in ", rec_id)
                 assert (
-                        list(val.keys())[0]
-                        in psm.backend._data[STANDARD_TEST_PIPE_ID][PROJECT_SAMPLE_LEVEL][rec_id]
+                    list(val.keys())[0]
+                    in psm.backend._data[STANDARD_TEST_PIPE_ID][PROJECT_SAMPLE_LEVEL][rec_id]
                 )
                 if backend == "file":
                     assert_is_in_files(results_file_path, str(list(val.values())[0]))
@@ -437,6 +437,40 @@ class TestRetrieval:
             assert str(retrieved_val) == str(list(val.values())[0])
             # Test Retrieve Whole Record
             assert isinstance(psm.retrieve(record_identifier=rec_id), Mapping)
+
+    @pytest.mark.parametrize(
+        ["rec_id", "val"],
+        [
+            ("sample1", {"name_of_something": "test_name"}),
+            ("sample1", {"number_of_things": 2}),
+        ],
+    )
+    @pytest.mark.parametrize("backend", ["file", "db"])
+    def test_retrieve_getitem(
+        self,
+        rec_id,
+        val,
+        config_file_path,
+        results_file_path,
+        schema_file_path,
+        backend,
+    ):
+        with NamedTemporaryFile() as f, ContextManagerDBTesting(DB_URL):
+            results_file_path = f.name
+            args = dict(schema_path=schema_file_path, database_only=False)
+            backend_data = (
+                {"config_file": config_file_path}
+                if backend == "db"
+                else {"results_file_path": results_file_path}
+            )
+            args.update(backend_data)
+            psm = SamplePipestatManager(**args)
+            psm.report(record_identifier=rec_id, values=val, force_overwrite=True)
+            retrieved_val = psm[rec_id]
+            # Test Retrieve Basic
+            assert str(retrieved_val[str(list(retrieved_val.keys())[0])]) == str(
+                list(val.values())[0]
+            )
 
     @pytest.mark.parametrize("backend", ["file", "db"])
     def test_retrieve_multiple(

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -17,7 +17,7 @@ def test_status_file_default_location(schema_file_path, results_file_path):
         results_file_path=results_file_path,
         schema_path=schema_file_path,
     )
-    assert psm.store[STATUS_FILE_DIR] == os.path.dirname(psm.store[FILE_KEY])
+    assert psm.cfg[STATUS_FILE_DIR] == os.path.dirname(psm.cfg[FILE_KEY])
 
 
 @pytest.mark.parametrize("backend_data", ["file", "db"], indirect=True)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -3,7 +3,7 @@
 import os
 import pytest
 from pipestat import SamplePipestatManager, SamplePipestatManager, ProjectPipestatManager
-from pipestat.const import STATUS_FILE_DIR
+from pipestat.const import STATUS_FILE_DIR, FILE_KEY
 from .conftest import BACKEND_KEY_DB, BACKEND_KEY_FILE, DB_URL
 
 from .test_db_only_mode import ContextManagerDBTesting
@@ -17,7 +17,7 @@ def test_status_file_default_location(schema_file_path, results_file_path):
         results_file_path=results_file_path,
         schema_path=schema_file_path,
     )
-    assert psm[STATUS_FILE_DIR] == os.path.dirname(psm.file)
+    assert psm.store[STATUS_FILE_DIR] == os.path.dirname(psm.store[FILE_KEY])
 
 
 @pytest.mark.parametrize("backend_data", ["file", "db"], indirect=True)


### PR DESCRIPTION
Adds `select_records`, `retrieve_one`, `retrieve_many ` interface, cursor_pagination for DBBackend.

Also refactored to store all configuration attributes in `psm.cfg`.

Changed magic functions, `__setitem__ `and `__getitem__`, to act as a wrapper for `report` and `retrieve` respectively.

Address #99 and #103

- [x] Delete `dynamic_filter` function and other, as we replaced it with new function