### PR TITLE
Align pipestat output_schema to be a true JSON schema

### DIFF
--- a/pipestat/backends/db_backend/dbbackend.py
+++ b/pipestat/backends/db_backend/dbbackend.py
@@ -53,7 +53,7 @@ class DBBackend(PipestatBackend):
         :param dict status_schema_source: filepath of status schema
         :param str result_formatter: function for formatting result
         """
-        _LOGGER.warning(f"Initializing DBBackend for pipeline '{pieline_name}'")
+        _LOGGER.warning(f"Initializing DBBackend for pipeline '{pipeline_name}'")
         self.pipeline_name = pipeline_name
         self.pipeline_type = pipeline_type or "sample"
         self.record_identifier = record_identifier

--- a/pipestat/parsed_schema.py
+++ b/pipestat/parsed_schema.py
@@ -28,28 +28,6 @@ SCHEMA_PIPELINE_NAME_KEY = "pipeline_name"
 
 # The columns associated with the file and image types
 PATH_COL_SPEC = (Path, ...)
-# TITLE_COL_SPEC = (Optional[str], Field(default=None))
-# THUMBNAIL_COL_SPEC = (Optional[Path], Field(default=None))
-
-
-# def _custom_types_column_specifications():
-#     """Collection of the column specifications for the custom types"""
-#     return {
-#         "path": PATH_COL_SPEC,
-#         "title": TITLE_COL_SPEC,
-#         "thumbnail": THUMBNAIL_COL_SPEC,
-#     }
-
-
-# def get_base_model():
-#     class BaseModel(SQLModel):
-#         __table_args__ = {"extend_existing": True}
-#
-#         class Config:
-#             arbitrary_types_allowed = True
-#
-#     # return SQLModel
-#     return BaseModel
 
 
 def _safe_pop_one_mapping(
@@ -103,6 +81,7 @@ class ParsedSchema(object):
         # Currently supporting backwards compatibility with old output schema while now also supporting a JSON schema:
         if "properties" in list(data.keys()):
             # Assume top-level properties key implies proper JSON schema.
+
             self._pipeline_name = data["properties"].pop(SCHEMA_PIPELINE_NAME_KEY, None)
 
             sample_data = _safe_pop_one_mapping(
@@ -125,6 +104,10 @@ class ParsedSchema(object):
                 info_name="status",
                 mappingkey="properties",
             )
+
+            sample_data = replace_JSON_refs(sample_data, data)
+
+            prj_data = replace_JSON_refs(prj_data, data)
 
         else:
             self._pipeline_name = data.pop(SCHEMA_PIPELINE_NAME_KEY, None)
@@ -225,38 +208,6 @@ class ParsedSchema(object):
         """Return the name of the database table for sample-level information."""
         return self._table_name("sample")
 
-    #
-    # def _make_field_definitions(self, data: Dict[str, Any], require_type: bool):
-    #     # TODO: default to string if no type key?
-    #     # TODO: parse "required" ?
-    #     defs = {}
-    #     for name, subdata in data.items():
-    #         try:
-    #             typename = subdata[SCHEMA_TYPE_KEY]
-    #         except KeyError:
-    #             if require_type:
-    #                 _LOGGER.error(f"'{SCHEMA_TYPE_KEY}' is required for each schema element")
-    #                 raise
-    #             else:
-    #                 data_type = str
-    #         else:
-    #             data_type = self._get_data_type(typename)
-    #         if data_type == CLASSES_BY_TYPE["object"] or data_type == CLASSES_BY_TYPE["array"]:
-    #             defs[name] = (
-    #                 data_type,
-    #                 Field(sa_column=Column(JSONB), default=null()),
-    #             )
-    #         else:
-    #             defs[name] = (
-    #                 # Optional[subdata[SCHEMA_TYPE_KEY]],
-    #                 # subdata[SCHEMA_TYPE_KEY],
-    #                 # Optional[str],
-    #                 # CLASSES_BY_TYPE[subdata[SCHEMA_TYPE_KEY]],
-    #                 data_type,
-    #                 Field(default=subdata.get("default")),
-    #             )
-    #     return defs
-
     @staticmethod
     def _get_data_type(type_name):
         t = CLASSES_BY_TYPE[type_name]
@@ -266,30 +217,6 @@ class ParsedSchema(object):
     @property
     def file_like_table_name(self):
         return self._table_name("files")
-
-    # def build_model(self, pipeline_type):
-    #     if pipeline_type == "project":
-    #         data = self.project_level_data
-    #         # if using the same output schema and thus, pipeline name for samples and project
-    #         # we must ensure there are distinct table names in the same database.
-    #         table_name = self.project_table_name
-    #
-    #     if pipeline_type == "sample":
-    #         data = self.sample_level_data
-    #         table_name = self.sample_table_name
-    #
-    #     if not self.sample_level_data and not self.project_level_data:
-    #         return None
-    #
-    #     field_defs = self._make_field_definitions(data, require_type=True)
-    #     field_defs = self._add_status_field(field_defs)
-    #     field_defs = self._add_record_identifier_field(field_defs)
-    #     field_defs = self._add_id_field(field_defs)
-    #     # field_defs = self._add_project_name_field(field_defs)
-    #     field_defs = self._add_pipeline_name_field(field_defs)
-    #     field_defs = self._add_created_time_field(field_defs)
-    #     field_defs = self._add_modified_time_field(field_defs)
-    #     return _create_model(table_name, **field_defs)
 
     def to_dict(self) -> Dict[str, Any]:
         """Create simple dictionary representation of this instance."""
@@ -303,97 +230,8 @@ class ParsedSchema(object):
                 data[key] = values
         return data
 
-    #
-    # @staticmethod
-    # def _add_project_name_field(field_defs: Dict[str, Any]) -> Dict[str, Any]:
-    #     if PROJECT_NAME in field_defs:
-    #         raise SchemaError(
-    #             f"'{PROJECT_NAME}' is reserved as identifier and can't be part of schema."
-    #         )
-    #     field_defs[PROJECT_NAME] = (str, Field(default=None))
-    #
-    #     return field_defs
-    #
-    # @staticmethod
-    # def _add_pipeline_name_field(field_defs: Dict[str, Any]) -> Dict[str, Any]:
-    #     if PIPELINE_NAME in field_defs:
-    #         raise SchemaError(
-    #             f"'{PIPELINE_NAME}' is reserved as identifier and can't be part of schema."
-    #         )
-    #     field_defs[PIPELINE_NAME] = (str, Field(default=None))
-    #
-    #     return field_defs
-    #
-    # @staticmethod
-    # def _add_id_field(field_defs: Dict[str, Any]) -> Dict[str, Any]:
-    #     if ID_KEY in field_defs:
-    #         raise SchemaError(
-    #             f"'{ID_KEY}' is reserved for primary key and can't be part of schema."
-    #         )
-    #     field_defs[ID_KEY] = (
-    #         Optional[int],
-    #         Field(default=None, primary_key=True),
-    #     )
-    #     return field_defs
-    #
-    # @staticmethod
-    # def _add_record_identifier_field(field_defs: Dict[str, Any]) -> Dict[str, Any]:
-    #     if RECORD_IDENTIFIER in field_defs:
-    #         raise SchemaError(
-    #             f"'{RECORD_IDENTIFIER}' is reserved as identifier and can't be part of schema."
-    #         )
-    #     field_defs[RECORD_IDENTIFIER] = (str, Field(default=None))
-    #     return field_defs
-    #
-    # @staticmethod
-    # def _add_sample_name_field(field_defs: Dict[str, Any]) -> Dict[str, Any]:
-    #     if SAMPLE_NAME in field_defs:
-    #         raise SchemaError(
-    #             f"'{SAMPLE_NAME}' is reserved as identifier and can't be part of schema."
-    #         )
-    #     field_defs[SAMPLE_NAME] = (str, Field(default=None))
-    #     return field_defs
-    #
-    # @staticmethod
-    # def _add_status_field(field_defs: Dict[str, Any]) -> Dict[str, Any]:
-    #     if STATUS in field_defs:
-    #         raise SchemaError(
-    #             f"'{STATUS}' is reserved for status reporting and can't be part of schema."
-    #         )
-    #     field_defs[STATUS] = (str, Field(default=None))
-    #     return field_defs
-    #
-    # @staticmethod
-    # def _add_created_time_field(field_defs: Dict[str, Any]) -> Dict[str, Any]:
-    #     if CREATED_TIME in field_defs:
-    #         raise SchemaError(
-    #             f"'{CREATED_TIME}' is reserved for time reporting and can't be part of schema."
-    #         )
-    #     field_defs[CREATED_TIME] = (datetime.datetime, Field(default=None))
-    #     return field_defs
-    #
-    # @staticmethod
-    # def _add_modified_time_field(field_defs: Dict[str, Any]) -> Dict[str, Any]:
-    #     if MODIFIED_TIME in field_defs:
-    #         raise SchemaError(
-    #             f"'{MODIFIED_TIME}' is reserved for time reporting and can't be part of schema."
-    #         )
-    #     field_defs[MODIFIED_TIME] = (datetime.datetime, Field(default=None))
-    #     return field_defs
-
     def _table_name(self, suffix: str) -> str:
         return f"{self.pipeline_name}__{suffix}"
-
-
-#
-# def _create_model(table_name: str, **kwargs):
-#     return create_model(
-#         table_name,
-#         __base__=get_base_model(),
-#         __cls_kwargs__={"table": True},
-#         **kwargs,
-#     )
-#
 
 
 def _recursively_replace_custom_types(s: Dict[str, Any]) -> Dict[str, Any]:
@@ -422,4 +260,38 @@ def _recursively_replace_custom_types(s: Dict[str, Any]) -> Dict[str, Any]:
         spec.setdefault(SCHEMA_PROP_KEY, {}).update(curr_type_spec[SCHEMA_PROP_KEY])
         spec.setdefault("required", []).extend(curr_type_spec["required"])
         spec[SCHEMA_TYPE_KEY] = curr_type_spec[SCHEMA_TYPE_KEY]
+    return s
+
+
+def replace_JSON_refs(s: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Recursively search and replace the $refs if they exist in schema, s, and if their corresponding $defs exist in
+    source schema, data
+
+    :param dict s: schema to replace types in
+    :param dict data: source schema
+    :return dict s: schema with types replaced
+    """
+
+    for k, v in list(s.items()):
+        if type(v) == dict:
+            replace_JSON_refs(s[k], data)
+        if "$ref" == k:
+            split_value = v.split("/")
+            if len(split_value) != 3:
+                raise SchemaError(
+                    msg=f"$ref exists in source schema but path,{v} ,not valid, e.g. '#/$defs/file' "
+                )
+            if split_value[1] in data and split_value[2] in data[split_value[1]]:
+                result = data[split_value[1]][split_value[2]]
+            else:
+                result = None
+            if result is not None:
+                s.update({split_value[2]: result})
+                s.update({"type": "object"})
+                del s["$ref"]
+            else:
+                raise SchemaError(
+                    msg=f"Could not find {split_value[1]} and {split_value[2]} in $def"
+                )
     return s

--- a/pipestat/parsed_schema.py
+++ b/pipestat/parsed_schema.py
@@ -104,7 +104,7 @@ class ParsedSchema(object):
                 info_name="status",
                 mappingkey="properties",
             )
-
+            # TODO We should add the ability to look at an external source beyond the source schema (data)
             sample_data = replace_JSON_refs(sample_data, data)
 
             prj_data = replace_JSON_refs(prj_data, data)

--- a/pipestat/parsed_schema.py
+++ b/pipestat/parsed_schema.py
@@ -274,7 +274,7 @@ def replace_JSON_refs(s: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]
     """
 
     for k, v in list(s.items()):
-        if type(v) == dict:
+        if isinstance(v, dict):
             replace_JSON_refs(s[k], data)
         if "$ref" == k:
             split_value = v.split("/")

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -413,42 +413,6 @@ class PipestatManager(MutableMapping):
             else:
                 self[STATUS_SCHEMA_SOURCE_KEY] = schema_to_read
 
-    def validate_schema(self) -> None:
-        """
-        Check schema for any possible issues
-
-        :raises SchemaError: if any schema format issue is detected
-        """
-
-        def _recursively_replace_custom_types(s: dict) -> Dict:
-            """
-            Replace the custom types in pipestat schema with canonical types
-
-            :param dict s: schema to replace types in
-            :return dict: schema with types replaced
-            """
-            for k, v in s.items():
-                missing_req_keys = [
-                    req for req in [SCHEMA_TYPE_KEY, SCHEMA_DESC_KEY] if req not in v
-                ]
-                if missing_req_keys:
-                    raise SchemaError(
-                        f"Result '{k}' is missing required key(s): {', '.join(missing_req_keys)}"
-                    )
-                curr_type_name = v[SCHEMA_TYPE_KEY]
-                if curr_type_name == "object" and SCHEMA_PROP_KEY in s[k]:
-                    _recursively_replace_custom_types(s[k][SCHEMA_PROP_KEY])
-                try:
-                    curr_type_spec = CANONICAL_TYPES[curr_type_name]
-                except KeyError:
-                    continue
-                s.setdefault(k, {})
-                s[k].setdefault(SCHEMA_PROP_KEY, {})
-                s[k][SCHEMA_PROP_KEY].update(curr_type_spec[SCHEMA_PROP_KEY])
-                s[k].setdefault("required", []).extend(curr_type_spec["required"])
-                s[k][SCHEMA_TYPE_KEY] = curr_type_spec[SCHEMA_TYPE_KEY]
-            return s
-
     @require_backend
     def remove(
         self,

--- a/tests/data/output_schema.yaml
+++ b/tests/data/output_schema.yaml
@@ -1,3 +1,12 @@
-result_name:
-  type: string
-  description: "ResultName"
+title: An example Pipestat output schema
+description: A pipeline that uses pipestat to report sample and project level results.
+type: object
+properties:
+  pipeline_name: "default_pipeline_name"
+  samples:
+    type: object
+    properties:
+        result_name:
+          type: string
+          description: "ResultName"
+

--- a/tests/data/output_schema_as_JSON_schema.yaml
+++ b/tests/data/output_schema_as_JSON_schema.yaml
@@ -9,24 +9,12 @@ properties:
         number_of_things:
           type: integer
           description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        smooth_bw:
-          type: string
-          description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce nec cursus nulla."
-          path: "aligned_{genome}/{sample_name}_smooth.bw"
         output_image:
-          type: image
+          $ref: "#/$defs/image"
           description: "This an output image"
-          properties:
-            path: "path string"
-            thumbnail_path: "path string to thumbnail"
-            title: "image title"
         output_file:
-          type: file
+          $ref: "#/$defs/file"
           description: "This a path to the output image"
-          properties:
-            path:
-              type: string
-              description: "path to string"
         collection_of_images:
           type: array
           description: A collection of images.
@@ -34,17 +22,17 @@ properties:
             type: object
             properties:
               prop1:
-                type: file
+                $ref: "#/$defs/file"
                 description: An example file.
-        output_file_in_object:
+        nested_object:
           type: object
-          description: An object containing output files.
+          description: An object containing output file and image.
           properties:
             example_property_1:
-              type: file
+              $ref: "#/$defs/file"
               description: An example file.
             example_property_2:
-              type: image
+              $ref: "#/$defs/image"
               description: An example image.
         output_file_nested_object:
           type: object
@@ -55,21 +43,38 @@ properties:
               description: Second Level
               properties:
                 third_level_property_1:
-                  type: file
+                  $ref: "#/$defs/file"
                   description: Third Level
             example_property_2:
               type: object
               description: Second Level
               properties:
                 third_level_property_1:
-                  type: file
+                  $ref: "#/$defs/file"
                   description: Third Level
-  project:
+$defs:
+  image:
     type: object
+    object_type: image
     properties:
-      project_output_file:
-        type: file
-        description: The path to the output file.
-      protocol:
+      path:
         type: string
-        description: example protocol description
+      thumbnail_path:
+        type: string
+      title:
+        type: string
+    required:
+      - path
+      - thumbnail_path
+      - title
+  file:
+    type: object
+    object_type: file
+    properties:
+      path:
+        type: string
+      title:
+        type: string
+    required:
+      - path
+      - title

--- a/tests/data/output_schema_html_report.yaml
+++ b/tests/data/output_schema_html_report.yaml
@@ -1,33 +1,67 @@
-pipeline_name: default_pipeline_name
-project:
-  number_of_things:
-    type: integer
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rutrum rhoncus tellus, ac euismod nisl mattis sit amet. Aenean scelerisque"
-  percentage_of_things:
-    type: number
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ultricies nunc orci, sed aliquam est."
-  name_of_something:
-    type: string
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ipsum erat, porta in condimentum viverra, pellentesque in nisl. Nulla rhoncus nibh est, quis malesuada diam suscipit at. In ut diam."
-  switch_value:
-    type: boolean
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras pharetra."
-samples:
-  smooth_bw:
-    path: "aligned_{genome}/{sample_name}_smooth.bw"
-    type: string
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce nec cursus nulla."
-  aligned_bam:
-    path: "aligned_{genome}/{sample_name}_sort.bam"
-    type: string
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ipsum erat, porta in condimentum viverra, pellentesque in nisl. Nulla rhoncus nibh est, quis malesuada diam suscipit at. In ut diam."
-  peaks_bed:
-    path: "peak_calling_{genome}/{sample_name}_peaks.bed"
-    type: string
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce nec cursus nulla."
-  output_file:
-    type: file
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce nec cursus nulla."
-  output_image:
-    type: image
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras pharetra."
+title: An example Pipestat output schema
+description: A pipeline that uses pipestat to report sample and project level results.
+type: object
+properties:
+  pipeline_name: "default_pipeline_name"
+  project:
+    type: object
+    properties:
+      number_of_things:
+        type: integer
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rutrum rhoncus tellus, ac euismod nisl mattis sit amet. Aenean scelerisque"
+      percentage_of_things:
+        type: number
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ultricies nunc orci, sed aliquam est."
+      name_of_something:
+        type: string
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ipsum erat, porta in condimentum viverra, pellentesque in nisl. Nulla rhoncus nibh est, quis malesuada diam suscipit at. In ut diam."
+      switch_value:
+        type: boolean
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras pharetra."
+  samples:
+    type: object
+    properties:
+      smooth_bw:
+        path: "aligned_{genome}/{sample_name}_smooth.bw"
+        type: string
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce nec cursus nulla."
+      aligned_bam:
+        path: "aligned_{genome}/{sample_name}_sort.bam"
+        type: string
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ipsum erat, porta in condimentum viverra, pellentesque in nisl. Nulla rhoncus nibh est, quis malesuada diam suscipit at. In ut diam."
+      peaks_bed:
+        path: "peak_calling_{genome}/{sample_name}_peaks.bed"
+        type: string
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce nec cursus nulla."
+      output_file:
+        $ref: "#/$defs/file"
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce nec cursus nulla."
+      output_image:
+        $ref: "#/$defs/image"
+        description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras pharetra."
+$defs:
+  image:
+    type: object
+    object_type: image
+    properties:
+      path:
+        type: string
+      thumbnail_path:
+        type: string
+      title:
+        type: string
+    required:
+      - path
+      - thumbnail_path
+      - title
+  file:
+    type: object
+    object_type: file
+    properties:
+      path:
+        type: string
+      title:
+        type: string
+    required:
+      - path
+      - title

--- a/tests/data/sample_output_schema.yaml
+++ b/tests/data/sample_output_schema.yaml
@@ -1,24 +1,56 @@
-pipeline_name: default_pipeline_name
-samples:
-  number_of_things:
-    type: integer
-    description: "Number of things"
-  percentage_of_things:
-    type: number
-    description: "Percentage of things"
-  name_of_something:
-    type: string
-    description: "Name of something"
-  switch_value:
-    type: boolean
-    description: "Is the switch on or off"
-  output_file:
-    type: file
-    description: "This a path to the output file"
-  output_image:
-    type: image
-    description: "This a path to the output image"
-  md5sum:
-    type: string
-    description: "MD5SUM of an object"
-    highlight: true
+title: An example Pipestat output schema
+description: A pipeline that uses pipestat to report sample and project level results.
+type: object
+properties:
+  pipeline_name: "default_pipeline_name"
+  samples:
+    type: object
+    properties:
+      number_of_things:
+        type: integer
+        description: "Number of things"
+      percentage_of_things:
+        type: number
+        description: "Percentage of things"
+      name_of_something:
+        type: string
+        description: "Name of something"
+      switch_value:
+        type: boolean
+        description: "Is the switch on or off"
+      output_file:
+        $ref: "#/$defs/file"
+        description: "This a path to the output file"
+      output_image:
+        $ref: "#/$defs/image"
+        description: "This a path to the output image"
+      md5sum:
+        type: string
+        description: "MD5SUM of an object"
+        highlight: true
+$defs:
+  image:
+    type: object
+    object_type: image
+    properties:
+      path:
+        type: string
+      thumbnail_path:
+        type: string
+      title:
+        type: string
+    required:
+      - path
+      - thumbnail_path
+      - title
+  file:
+    type: object
+    object_type: file
+    properties:
+      path:
+        type: string
+      title:
+        type: string
+    required:
+      - path
+      - title

--- a/tests/data/sample_output_schema__with_project_with_samples_with_status.yaml
+++ b/tests/data/sample_output_schema__with_project_with_samples_with_status.yaml
@@ -1,37 +1,47 @@
-pipeline_name: default_pipeline_name
-project:
-  number_of_things:
-    type: integer
-    description: "Number of things"
-  percentage_of_things:
-    type: number
-    description: "Percentage of things"
-  name_of_something:
-    type: string
-    description: "Name of something"
-  switch_value:
-    type: boolean
-    description: "Is the switch on or off"
-samples:
-  smooth_bw:
-    path: "aligned_{genome}/{sample_name}_smooth.bw"
-    type: string
-    description: "A smooth bigwig file"
-  aligned_bam:
-    path: "aligned_{genome}/{sample_name}_sort.bam"
-    type: string
-    description: "A sorted, aligned BAM file"
-  peaks_bed:
-    path: "peak_calling_{genome}/{sample_name}_peaks.bed"
-    type: string
-    description: "Peaks in BED format"
-status:
-  completed:
-    description: "the pipeline has completed"
-    color: [1, 205, 1]
-  waiting:
-    description: "the pipeline is waiting"
-    color: [240, 230, 140]
-  partial:
-    description: "the pipeline stopped before completion point"
-    color: [100, 100, 100]
+title: An example Pipestat output schema
+description: A pipeline that uses pipestat to report sample and project level results.
+type: object
+properties:
+  pipeline_name: "default_pipeline_name"
+  project:
+    type: object
+    properties:
+      number_of_things:
+        type: integer
+        description: "Number of things"
+      percentage_of_things:
+        type: number
+        description: "Percentage of things"
+      name_of_something:
+        type: string
+        description: "Name of something"
+      switch_value:
+        type: boolean
+        description: "Is the switch on or off"
+  samples:
+    type: object
+    properties:
+      smooth_bw:
+        path: "aligned_{genome}/{sample_name}_smooth.bw"
+        type: string
+        description: "A smooth bigwig file"
+      aligned_bam:
+        path: "aligned_{genome}/{sample_name}_sort.bam"
+        type: string
+        description: "A sorted, aligned BAM file"
+      peaks_bed:
+        path: "peak_calling_{genome}/{sample_name}_peaks.bed"
+        type: string
+        description: "Peaks in BED format"
+  status:
+    type: object
+    properties:
+      completed:
+        description: "the pipeline has completed"
+        color: [1, 205, 1]
+      waiting:
+        description: "the pipeline is waiting"
+        color: [240, 230, 140]
+      partial:
+        description: "the pipeline stopped before completion point"
+        color: [100, 100, 100]

--- a/tests/data/sample_output_schema__with_project_with_samples_without_status.yaml
+++ b/tests/data/sample_output_schema__with_project_with_samples_without_status.yaml
@@ -1,27 +1,35 @@
-pipeline_name: default_pipeline_name
-project:
-  number_of_things:
-    type: integer
-    description: "Number of things"
-  percentage_of_things:
-    type: number
-    description: "Percentage of things"
-  name_of_something:
-    type: string
-    description: "Name of something"
-  switch_value:
-    type: boolean
-    description: "Is the switch on or off"
-samples:
-  smooth_bw:
-    path: "aligned_{genome}/{sample_name}_smooth.bw"
-    type: string
-    description: "A smooth bigwig file"
-  aligned_bam:
-    path: "aligned_{genome}/{sample_name}_sort.bam"
-    type: string
-    description: "A sorted, aligned BAM file"
-  peaks_bed:
-    path: "peak_calling_{genome}/{sample_name}_peaks.bed"
-    type: string
-    description: "Peaks in BED format"
+title: An example Pipestat output schema
+description: A pipeline that uses pipestat to report sample and project level results.
+type: object
+properties:
+  pipeline_name: "default_pipeline_name"
+  project:
+    type: object
+    properties:
+      number_of_things:
+        type: integer
+        description: "Number of things"
+      percentage_of_things:
+        type: number
+        description: "Percentage of things"
+      name_of_something:
+        type: string
+        description: "Name of something"
+      switch_value:
+        type: boolean
+        description: "Is the switch on or off"
+  samples:
+    type: object
+    properties:
+      smooth_bw:
+        path: "aligned_{genome}/{sample_name}_smooth.bw"
+        type: string
+        description: "A smooth bigwig file"
+      aligned_bam:
+        path: "aligned_{genome}/{sample_name}_sort.bam"
+        type: string
+        description: "A sorted, aligned BAM file"
+      peaks_bed:
+        path: "peak_calling_{genome}/{sample_name}_peaks.bed"
+        type: string
+        description: "Peaks in BED format"

--- a/tests/data/sample_output_schema__with_project_without_samples_with_status.yaml
+++ b/tests/data/sample_output_schema__with_project_without_samples_with_status.yaml
@@ -1,24 +1,32 @@
-pipeline_name: default_pipeline_name
-project:
-  number_of_things:
-    type: integer
-    description: "Number of things"
-  percentage_of_things:
-    type: number
-    description: "Percentage of things"
-  name_of_something:
-    type: string
-    description: "Name of something"
-  switch_value:
-    type: boolean
-    description: "Is the switch on or off"
-status:
-  completed:
-    description: "the pipeline has completed"
-    color: [ 1, 205, 1 ]
-  waiting:
-    description: "the pipeline is waiting"
-    color: [ 240, 230, 140 ]
-  partial:
-    description: "the pipeline stopped before completion point"
-    color: [ 100, 100, 100 ]
+title: An example Pipestat output schema
+description: A pipeline that uses pipestat to report sample and project level results.
+type: object
+properties:
+  pipeline_name: "default_pipeline_name"
+  project:
+    type: object
+    properties:
+      number_of_things:
+        type: integer
+        description: "Number of things"
+      percentage_of_things:
+        type: number
+        description: "Percentage of things"
+      name_of_something:
+        type: string
+        description: "Name of something"
+      switch_value:
+        type: boolean
+        description: "Is the switch on or off"
+  status:
+    type: object
+    properties:
+      completed:
+        description: "the pipeline has completed"
+        color: [1, 205, 1]
+      waiting:
+        description: "the pipeline is waiting"
+        color: [240, 230, 140]
+      partial:
+        description: "the pipeline stopped before completion point"
+        color: [100, 100, 100]

--- a/tests/data/sample_output_schema__with_project_without_samples_without_status.yaml
+++ b/tests/data/sample_output_schema__with_project_without_samples_without_status.yaml
@@ -1,14 +1,20 @@
-pipeline_name: default_pipeline_name
-project:
-  percentage_of_things:
-    type: "number"
-    description: "Percentage of things"
-  name_of_something:
-    type: "string"
-    description: "Name of something"
-  number_of_things:
-    type: "integer"
-    description: "Number of things"
-  switch_value:
-    type: "boolean"
-    description: "Is the switch on or off"
+title: An example Pipestat output schema
+description: A pipeline that uses pipestat to report sample and project level results.
+type: object
+properties:
+  pipeline_name: "default_pipeline_name"
+  project:
+    type: object
+    properties:
+      number_of_things:
+        type: integer
+        description: "Number of things"
+      percentage_of_things:
+        type: number
+        description: "Percentage of things"
+      name_of_something:
+        type: string
+        description: "Name of something"
+      switch_value:
+        type: boolean
+        description: "Is the switch on or off"

--- a/tests/data/sample_output_schema__without_project_with_samples_with_status.yaml
+++ b/tests/data/sample_output_schema__without_project_with_samples_with_status.yaml
@@ -1,24 +1,32 @@
-pipeline_name: default_pipeline_name
-samples:
-  smooth_bw:
-    path: "aligned_{genome}/{sample_name}_smooth.bw"
-    type: string
-    description: "A smooth bigwig file"
-  aligned_bam:
-    path: "aligned_{genome}/{sample_name}_sort.bam"
-    type: string
-    description: "A sorted, aligned BAM file"
-  peaks_bed:
-    path: "peak_calling_{genome}/{sample_name}_peaks.bed"
-    type: string
-    description: "Peaks in BED format"
-status:
-  completed:
-    description: "the pipeline has completed"
-    color: [ 1, 205, 1 ]
-  waiting:
-    description: "the pipeline is waiting"
-    color: [ 240, 230, 140 ]
-  partial:
-    description: "the pipeline stopped before completion point"
-    color: [ 100, 100, 100 ]
+title: An example Pipestat output schema
+description: A pipeline that uses pipestat to report sample and project level results.
+type: object
+properties:
+  pipeline_name: "default_pipeline_name"
+  samples:
+    type: object
+    properties:
+      smooth_bw:
+        path: "aligned_{genome}/{sample_name}_smooth.bw"
+        type: string
+        description: "A smooth bigwig file"
+      aligned_bam:
+        path: "aligned_{genome}/{sample_name}_sort.bam"
+        type: string
+        description: "A sorted, aligned BAM file"
+      peaks_bed:
+        path: "peak_calling_{genome}/{sample_name}_peaks.bed"
+        type: string
+        description: "Peaks in BED format"
+  status:
+    type: object
+    properties:
+      completed:
+        description: "the pipeline has completed"
+        color: [1, 205, 1]
+      waiting:
+        description: "the pipeline is waiting"
+        color: [240, 230, 140]
+      partial:
+        description: "the pipeline stopped before completion point"
+        color: [100, 100, 100]

--- a/tests/data/sample_output_schema__without_project_with_samples_without_status.yaml
+++ b/tests/data/sample_output_schema__without_project_with_samples_without_status.yaml
@@ -1,14 +1,20 @@
-pipeline_name: default_pipeline_name
-samples:
-  smooth_bw:
-    path: "aligned_{genome}/{sample_name}_smooth.bw"
-    type: string
-    description: "A smooth bigwig file"
-  aligned_bam:
-    path: "aligned_{genome}/{sample_name}_sort.bam"
-    type: string
-    description: "A sorted, aligned BAM file"
-  peaks_bed:
-    path: "peak_calling_{genome}/{sample_name}_peaks.bed"
-    type: string
-    description: "Peaks in BED format"
+title: An example Pipestat output schema
+description: A pipeline that uses pipestat to report sample and project level results.
+type: object
+properties:
+  pipeline_name: "default_pipeline_name"
+  samples:
+    type: object
+    properties:
+      smooth_bw:
+        path: "aligned_{genome}/{sample_name}_smooth.bw"
+        type: string
+        description: "A smooth bigwig file"
+      aligned_bam:
+        path: "aligned_{genome}/{sample_name}_sort.bam"
+        type: string
+        description: "A sorted, aligned BAM file"
+      peaks_bed:
+        path: "peak_calling_{genome}/{sample_name}_peaks.bed"
+        type: string
+        description: "Peaks in BED format"

--- a/tests/data/sample_output_schema_highlight.yaml
+++ b/tests/data/sample_output_schema_highlight.yaml
@@ -1,43 +1,75 @@
-pipeline_name: default_pipeline_name
-samples:
-  number_of_things:
-    type: integer
-    description: "Number of things"
-  percentage_of_things:
-    type: number
-    description: "Percentage of things"
-  name_of_something:
-    type: string
-    description: "Name of something"
-  switch_value:
-    type: boolean
-    description: "Is the switch on or off"
-  collection_of_things:
-    type: array
-    description: "This store collection of values"
-  output_object:
+title: An example Pipestat output schema
+description: A pipeline that uses pipestat to report sample and project level results.
+type: object
+properties:
+  pipeline_name: "default_pipeline_name"
+  samples:
     type: object
-    description: "Object output"
-  output_file:
-    type: file
-    description: "This a path to the output file"
-  output_image:
-    type: image
-    highlight: false
-    description: "This a path to the output image"
-  log:
-    type: file
-    highlight: true
-    description: "The log file of the pipeline run"
-  profile:
-    type: file
-    highlight: true
-    description: "The profile of the pipeline run"
-  commands:
-    type: file
-    highlight: true
-    description: "The file with shell commands executed by this pipeline"
-  version:
-    type: string
-    highlight: true
-    description: "Pipeline version"
+    properties:
+      number_of_things:
+        type: integer
+        description: "Number of things"
+      percentage_of_things:
+        type: number
+        description: "Percentage of things"
+      name_of_something:
+        type: string
+        description: "Name of something"
+      switch_value:
+        type: boolean
+        description: "Is the switch on or off"
+      collection_of_things:
+        type: array
+        description: "This store collection of values"
+      output_object:
+        type: object
+        description: "Object output"
+      output_file:
+        $ref: "#/$defs/file"
+        description: "This a path to the output file"
+      output_image:
+        $ref: "#/$defs/image"
+        highlight: false
+        description: "This a path to the output image"
+      log:
+        $ref: "#/$defs/file"
+        highlight: true
+        description: "The log file of the pipeline run"
+      profile:
+        $ref: "#/$defs/file"
+        highlight: true
+        description: "The profile of the pipeline run"
+      commands:
+        $ref: "#/$defs/file"
+        highlight: true
+        description: "The file with shell commands executed by this pipeline"
+      version:
+        type: string
+        highlight: true
+        description: "Pipeline version"
+$defs:
+  image:
+    type: object
+    object_type: image
+    properties:
+      path:
+        type: string
+      thumbnail_path:
+        type: string
+      title:
+        type: string
+    required:
+      - path
+      - thumbnail_path
+      - title
+  file:
+    type: object
+    object_type: file
+    properties:
+      path:
+        type: string
+      title:
+        type: string
+    required:
+      - path
+      - title

--- a/tests/data/sample_output_schema_recursive.yaml
+++ b/tests/data/sample_output_schema_recursive.yaml
@@ -1,26 +1,58 @@
-pipeline_name: default_pipeline_name
-samples:
-  collection_of_images:
-    description: "This store collection of values or objects"
-    type: array
-    items:
-      properties:
-          prop1:
-            description: "This is an example file"
-            type: file
-  output_file_in_object:
+title: An example Pipestat output schema
+description: A pipeline that uses pipestat to report sample and project level results.
+type: object
+properties:
+  pipeline_name: "default_pipeline_name"
+  samples:
     type: object
     properties:
-      prop1:
-        description: "This is an example file"
-        type: file
-      prop2:
-        description: "This is an example image"
-        type: image
-    description: "Object output"
-  output_file:
-    type: file
-    description: "This a path to the output file"
-  output_image:
-    type: image
-    description: "This a path to the output image"
+      collection_of_images:
+        description: "This store collection of values or objects"
+        type: array
+        items:
+          properties:
+              prop1:
+                description: "This is an example file"
+                $ref: "#/$defs/file"
+      output_file_in_object:
+        type: object
+        properties:
+          prop1:
+            description: "This is an example file"
+            $ref: "#/$defs/file"
+          prop2:
+            description: "This is an example image"
+            $ref: "#/$defs/image"
+        description: "Object output"
+      output_file:
+        $ref: "#/$defs/file"
+        description: "This a path to the output file"
+      output_image:
+        $ref: "#/$defs/image"
+        description: "This a path to the output image"
+$defs:
+  image:
+    type: object
+    object_type: image
+    properties:
+      path:
+        type: string
+      thumbnail_path:
+        type: string
+      title:
+        type: string
+    required:
+      - path
+      - thumbnail_path
+      - title
+  file:
+    type: object
+    object_type: file
+    properties:
+      path:
+        type: string
+      title:
+        type: string
+    required:
+      - path
+      - title

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -49,11 +49,15 @@ class TestPipestatManagerInstantiation:
         )
         assert (
             "path"
-            in psm.result_schemas["output_file_in_object"]["properties"]["prop1"]["file"]['properties']
+            in psm.result_schemas["output_file_in_object"]["properties"]["prop1"]["file"][
+                "properties"
+            ]
         )
         assert (
             "thumbnail_path"
-            in psm.result_schemas["output_file_in_object"]["properties"]["prop2"]["image"]["properties"]
+            in psm.result_schemas["output_file_in_object"]["properties"]["prop2"]["image"][
+                "properties"
+            ]
         )
 
     def test_missing_cfg_data(self, schema_file_path):
@@ -93,10 +97,10 @@ class TestPipestatManagerInstantiation:
         assert os.path.exists(tmp_res_file)
         with open(schema_file_path, "r") as init_schema_file:
             init_schema = oyaml.safe_load(init_schema_file)
-        assert psm1.schema.pipeline_name == init_schema['properties'][SCHEMA_PIPELINE_NAME_KEY]
+        assert psm1.schema.pipeline_name == init_schema["properties"][SCHEMA_PIPELINE_NAME_KEY]
         ns2 = "namespace2"
         temp_schema_path = str(tmp_path / "schema.yaml")
-        init_schema['properties'][SCHEMA_PIPELINE_NAME_KEY] = ns2
+        init_schema["properties"][SCHEMA_PIPELINE_NAME_KEY] = ns2
         with open(temp_schema_path, "w") as temp_schema_file:
             dump(init_schema, temp_schema_file)
         with pytest.raises(PipestatError) as exc_ctx:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -49,11 +49,11 @@ class TestPipestatManagerInstantiation:
         )
         assert (
             "path"
-            in psm.result_schemas["output_file_in_object"]["properties"]["prop1"]["properties"]
+            in psm.result_schemas["output_file_in_object"]["properties"]["prop1"]["file"]['properties']
         )
         assert (
             "thumbnail_path"
-            in psm.result_schemas["output_file_in_object"]["properties"]["prop2"]["properties"]
+            in psm.result_schemas["output_file_in_object"]["properties"]["prop2"]["image"]["properties"]
         )
 
     def test_missing_cfg_data(self, schema_file_path):
@@ -93,10 +93,10 @@ class TestPipestatManagerInstantiation:
         assert os.path.exists(tmp_res_file)
         with open(schema_file_path, "r") as init_schema_file:
             init_schema = oyaml.safe_load(init_schema_file)
-        assert psm1.schema.pipeline_name == init_schema[SCHEMA_PIPELINE_NAME_KEY]
+        assert psm1.schema.pipeline_name == init_schema['properties'][SCHEMA_PIPELINE_NAME_KEY]
         ns2 = "namespace2"
         temp_schema_path = str(tmp_path / "schema.yaml")
-        init_schema[SCHEMA_PIPELINE_NAME_KEY] = ns2
+        init_schema['properties'][SCHEMA_PIPELINE_NAME_KEY] = ns2
         with open(temp_schema_path, "w") as temp_schema_file:
             dump(init_schema, temp_schema_file)
         with pytest.raises(PipestatError) as exc_ctx:

--- a/tests/test_parsed_schema.py
+++ b/tests/test_parsed_schema.py
@@ -262,4 +262,3 @@ def test_sample_project_data_item_name_overlap__raises_expected_error_and_messag
 def test_JSON_schema_validation(output_schema_as_JSON_schema):
     schema = ParsedSchema(output_schema_as_JSON_schema)
     assert "number_of_things" in dict(schema.sample_level_data).keys()
-    assert "protocol" in dict(schema.project_level_data).keys()

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -1158,7 +1158,7 @@ class TestFileTypeLinking:
             },
             {
                 "sample2": {
-                    "output_file_in_object": {
+                    "nested_object": {
                         "example_property_1": {
                             "path": path_file_1,
                             "thumbnail_path": "path_string",


### PR DESCRIPTION
Continued work towards: https://github.com/pepkit/pipestat/issues/85

It was discovered that JSON schema does not have types such as `image` or `file`. Therefore, this change allows the use of $defs and $ref to define custom object types such that they can be JSON objects and still have required attrributes such as `path` as well as an `object_type` field that will allow for distinguishing between these custom objects:

```
title: An example Pipestat output schema
description: A pipeline that uses pipestat to report sample and project level results.
type: object
properties:
  pipeline_name: "default_pipeline_name"
  samples:
    type: object
    properties:
        output_image:
          $ref: "#/$defs/image"
          description: "This an output image"
        output_file:
          $ref: "#/$defs/file"
          description: "This a path to the output image"
$defs:
  image:
    type: object
    object_type: image
    properties:
      path:
        type: string
      thumbnail_path:
        type: string
      title:
        type: string
    required:
      - path
      - thumbnail_path
      - title
  file:
    type: object
    object_type: file
    properties:
      path:
        type: string
      title:
        type: string
    required:
      - path
      - title
```
