### PR TITLE
single result file per sample if given `{record_identifier}` in the result_file_path

### DIFF
--- a/pipestat/backends/abstract.py
+++ b/pipestat/backends/abstract.py
@@ -1,6 +1,7 @@
 import os
 from abc import ABC
 from logging import getLogger
+from ubiquerg import expandpath
 from typing import List, Dict, Any, Optional, Union, Tuple
 
 from ..const import PKG_NAME, STATUS
@@ -99,6 +100,8 @@ class PipestatBackend(ABC):
             return key_value_pairs
 
         unique_result_identifiers = []
+
+        link_dir = expandpath(link_dir)
 
         all_records = self.select_records()
 

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -16,7 +16,6 @@ from typing import List, Dict, Any, Optional, Union, Literal, Callable, Tuple
 from ...exceptions import UnrecognizedStatusError, PipestatError
 from ...backends.abstract import PipestatBackend
 from ...const import DATE_FORMAT, PKG_NAME, CREATED_TIME, MODIFIED_TIME
-from ...helpers import resolve_multi_results_file_path
 
 
 _LOGGER = getLogger(PKG_NAME)
@@ -34,7 +33,6 @@ class FileBackend(PipestatBackend):
         status_file_dir: Optional[str] = None,
         result_formatter: Optional[staticmethod] = None,
         multi_pipelines: Optional[bool] = None,
-        multi_result_files: Optional[bool] = False,
     ):
         """
         Class representing a File backend
@@ -64,7 +62,6 @@ class FileBackend(PipestatBackend):
         self.status_file_dir = status_file_dir
         self.result_formatter = result_formatter
         self.multi_pipelines = multi_pipelines
-        self.multi_result_files = multi_result_files
 
         self.determine_results_file(self.results_file_path)
 
@@ -347,10 +344,6 @@ class FileBackend(PipestatBackend):
         # record_identifier = record_identifier or self.record_identifier
         record_identifier = record_identifier
 
-        if self.multi_result_files:
-            # Load this record identifier's results file
-            self.results_file_path = resolve_multi_results_file_path(self.results_file_path, record_identifier)
-            self.determine_results_file(self.results_file_path)
 
         result_formatter = result_formatter or self.result_formatter
         results_formatted = []

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -665,9 +665,17 @@ class FileBackend(PipestatBackend):
         with self._data as data_locked:
             data_locked.write()
 
-    def aggregate_multi_results(self, results_directory):
-        print(f"results directory {results_directory}")
+    def aggregate_multi_results(self, results_directory) -> None:
+        """
+        Collects single results files and aggregates them into a new aggregate_results.yaml file
+        :param str results_directory: directory containing subdirectories containing results.yaml files
+        :return: None
+        """
         all_result_files = get_all_result_files(results_directory)
+        if len(all_result_files) == 0:
+            _LOGGER.warning(
+                "Attempting to aggregate multiple results files but no result files found. Ensure they are in subdirectories, e.g. 'record1/record1_results.yaml'"
+            )
         aggregate_results_file_path = os.path.join(results_directory, "aggregate_results.yaml")
 
         # THIS WILL OVERWRITE self.results_file_path and self._data on the current psm!

--- a/pipestat/backends/file_backend/filebackend.py
+++ b/pipestat/backends/file_backend/filebackend.py
@@ -66,7 +66,6 @@ class FileBackend(PipestatBackend):
 
         self.determine_results_file(self.results_file_path)
 
-
     def determine_results_file(self, results_file_path: str) -> None:
         """Initialize or load results_file from given path
         :param str results_file_path: YAML file to report into, if file is
@@ -344,7 +343,6 @@ class FileBackend(PipestatBackend):
 
         # record_identifier = record_identifier or self.record_identifier
         record_identifier = record_identifier
-
 
         result_formatter = result_formatter or self.result_formatter
         results_formatted = []
@@ -670,7 +668,7 @@ class FileBackend(PipestatBackend):
     def aggregate_multi_results(self, results_directory):
         print(f"results directory {results_directory}")
         all_result_files = get_all_result_files(results_directory)
-        aggregate_results_file_path = os.path.join(results_directory,"aggregate_results.yaml")
+        aggregate_results_file_path = os.path.join(results_directory, "aggregate_results.yaml")
 
         # THIS WILL OVERWRITE self.results_file_path and self._data on the current psm!
         self.results_file_path = aggregate_results_file_path
@@ -683,9 +681,13 @@ class FileBackend(PipestatBackend):
                 temp_data = YAMLConfigManager()
             if self.pipeline_name in temp_data:
                 if "project" in temp_data[self.pipeline_name]:
-                    self._data[self.pipeline_name]["project"].update(temp_data[self.pipeline_name]["project"])
+                    self._data[self.pipeline_name]["project"].update(
+                        temp_data[self.pipeline_name]["project"]
+                    )
                 if "sample" in temp_data[self.pipeline_name]:
-                    self._data[self.pipeline_name]["sample"].update(temp_data[self.pipeline_name]["sample"])
+                    self._data[self.pipeline_name]["sample"].update(
+                        temp_data[self.pipeline_name]["sample"]
+                    )
 
         with self._data as data_locked:
             data_locked.write()

--- a/pipestat/const.py
+++ b/pipestat/const.py
@@ -63,7 +63,6 @@ __all__ = [
     "RECORD_IDENTIFIER",
     "CREATED_TIME",
     "MODIFIED_TIME",
-    "MULTI_RESULT_FILES"
 ]
 
 PKG_NAME = "pipestat"
@@ -159,7 +158,6 @@ PIPESTAT_GENERIC_CONFIG = "generic_config.yaml"
 RESULT_FORMATTER = "_result_formatter"
 DEFAULT_PIPELINE_NAME = "default_pipeline_name"
 MULTI_PIPELINE = "_multi_pipelines"
-MULTI_RESULT_FILES = "multi_result_files"
 TEMPLATES_DIRNAME = "jinja_templates"
 OUTPUT_DIR = "_output_dir"
 

--- a/pipestat/const.py
+++ b/pipestat/const.py
@@ -63,6 +63,7 @@ __all__ = [
     "RECORD_IDENTIFIER",
     "CREATED_TIME",
     "MODIFIED_TIME",
+    "MULTI_RESULT_FILES"
 ]
 
 PKG_NAME = "pipestat"
@@ -158,6 +159,7 @@ PIPESTAT_GENERIC_CONFIG = "generic_config.yaml"
 RESULT_FORMATTER = "_result_formatter"
 DEFAULT_PIPELINE_NAME = "default_pipeline_name"
 MULTI_PIPELINE = "_multi_pipelines"
+MULTI_RESULT_FILES = "multi_result_files"
 TEMPLATES_DIRNAME = "jinja_templates"
 OUTPUT_DIR = "_output_dir"
 

--- a/pipestat/helpers.py
+++ b/pipestat/helpers.py
@@ -8,7 +8,7 @@ import yaml
 import jsonschema
 from json import dumps
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union, List
 
 from oyaml import safe_load
 from ubiquerg import expandpath
@@ -220,7 +220,12 @@ def force_symlink(file1, file2):
             os.symlink(file1, file2)
 
 
-def get_all_result_files(results_file_path):
+def get_all_result_files(results_file_path: str) -> List:
+    """
+    Collects any yaml result files relative to the CURRENT results_file_path
+    :param str results_file_path: path to the pipestamanager's current result_file
+    :return: list
+    """
     files = glob.glob(results_file_path + "**/*.yaml")
-    # get parent directory, glob all results files, build one results file return
+
     return files

--- a/pipestat/helpers.py
+++ b/pipestat/helpers.py
@@ -209,3 +209,20 @@ def force_symlink(file1, file2):
             )
             os.remove(file2)
             os.symlink(file1, file2)
+
+def determine_multi_results_files(results_file_path):
+    "Simply determine if there is {record_identifier} present"
+    if "{record_identifier}" in results_file_path:
+        return True
+    else:
+        return False
+
+def resolve_multi_results_file_path(results_file_path, record_identifier):
+    f"Replace {record_identifier} in results_file_path"
+    results_file_path = results_file_path.format(record_identifier=record_identifier)
+    return results_file_path
+
+def get_all_result_files(results_file_path):
+    # get parent directory, glob all results files, build one results file return
+    pass
+

--- a/pipestat/helpers.py
+++ b/pipestat/helpers.py
@@ -1,6 +1,7 @@
 """Assorted project utilities"""
 
 import logging
+import glob
 import os
 import errno
 import yaml
@@ -115,11 +116,19 @@ def mk_abs_via_cfg(
         return path
     if cfg_path is None:
         rel_to_cwd = os.path.join(os.getcwd(), path)
+        try:
+            os.makedirs(os.path.dirname(rel_to_cwd))
+        except FileExistsError:
+            pass
         if os.path.exists(rel_to_cwd) or os.access(os.path.dirname(rel_to_cwd), os.W_OK):
             return rel_to_cwd
         else:
             raise OSError(f"File not found: {path}")
     joined = os.path.join(os.path.dirname(cfg_path), path)
+    try:
+        os.makedirs(os.path.dirname(joined))
+    except FileExistsError:
+        pass
     if os.path.isabs(joined):
         return joined
     raise OSError(f"Could not make this path absolute: {path}")
@@ -212,6 +221,7 @@ def force_symlink(file1, file2):
 
 
 def get_all_result_files(results_file_path):
+    files = glob.glob(results_file_path+'**/*.yaml')
     # get parent directory, glob all results files, build one results file return
-    pass
+    return files
 

--- a/pipestat/helpers.py
+++ b/pipestat/helpers.py
@@ -210,17 +210,6 @@ def force_symlink(file1, file2):
             os.remove(file2)
             os.symlink(file1, file2)
 
-def determine_multi_results_files(results_file_path):
-    "Simply determine if there is {record_identifier} present"
-    if "{record_identifier}" in results_file_path:
-        return True
-    else:
-        return False
-
-def resolve_multi_results_file_path(results_file_path, record_identifier):
-    f"Replace {record_identifier} in results_file_path"
-    results_file_path = results_file_path.format(record_identifier=record_identifier)
-    return results_file_path
 
 def get_all_result_files(results_file_path):
     # get parent directory, glob all results files, build one results file return

--- a/pipestat/helpers.py
+++ b/pipestat/helpers.py
@@ -221,7 +221,6 @@ def force_symlink(file1, file2):
 
 
 def get_all_result_files(results_file_path):
-    files = glob.glob(results_file_path+'**/*.yaml')
+    files = glob.glob(results_file_path + "**/*.yaml")
     # get parent directory, glob all results files, build one results file return
     return files
-

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -198,12 +198,14 @@ class PipestatManager(MutableMapping):
             "pipeline_type", default="sample", override=pipeline_type
         )
 
-        self.cfg[FILE_KEY] = mk_abs_via_cfg(self.resolve_results_file_path(
-            self.cfg[CONFIG_KEY].priority_get(
-                "results_file_path",
-                env_var=ENV_VARS["results_file"],
-                override=results_file_path,
-            )),
+        self.cfg[FILE_KEY] = mk_abs_via_cfg(
+            self.resolve_results_file_path(
+                self.cfg[CONFIG_KEY].priority_get(
+                    "results_file_path",
+                    env_var=ENV_VARS["results_file"],
+                    override=results_file_path,
+                )
+            ),
             self.cfg["config_path"],
         )
 
@@ -290,15 +292,16 @@ class PipestatManager(MutableMapping):
         if results_file_path:
             assert isinstance(results_file_path, str), TypeError("Path is expected to be a str")
             if not self.record_identifier and "{record_identifier}" in results_file_path:
-                raise NotImplementedError(f"Must provide record identifier during PipestatManager creation for this results_file_path: {results_file_path}")
+                raise NotImplementedError(
+                    f"Must provide record identifier during PipestatManager creation for this results_file_path: {results_file_path}"
+                )
             self.cfg["unresolved_result_path"] = results_file_path
             return results_file_path.format(record_identifier=self.record_identifier)
         return results_file_path
-    def initialize_filebackend(self, record_identifier, results_file_path, flag_file_dir):
 
+    def initialize_filebackend(self, record_identifier, results_file_path, flag_file_dir):
         # Check if there will be multiple results_file_paths
         _LOGGER.debug(f"Determined file as backend: {results_file_path}")
-
 
         if self.cfg[DB_ONLY_KEY]:
             _LOGGER.debug(
@@ -760,7 +763,9 @@ class PipestatManager(MutableMapping):
         if self.file and self.cfg["unresolved_result_path"] != self.file:
             if "{record_identifier}" in self.cfg["unresolved_result_path"]:
                 # assume there are multiple result files in sub-directories
-                results_directory = self.cfg["unresolved_result_path"].split("{record_identifier}")[0]
+                results_directory = self.cfg["unresolved_result_path"].split(
+                    "{record_identifier}"
+                )[0]
                 results_directory = mk_abs_via_cfg(results_directory, self.cfg["config_path"])
                 self.backend.aggregate_multi_results(results_directory)
 

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -1078,7 +1078,10 @@ def _create_stats_objs_summaries(prj, pipeline_name: str) -> List[str]:
             if v:
                 if k in prj.result_schemas and prj.result_schemas[k]["type"] in OBJECT_TYPES:
                     sample_reported_objects = {k: dict(v)}
-                    reported_objects[record_name] = sample_reported_objects
+                    if record_name in reported_objects:
+                        reported_objects[record_name].update(sample_reported_objects)
+                    else:
+                        reported_objects.update({record_name: sample_reported_objects})
                 if k in prj.result_schemas and prj.result_schemas[k]["type"] not in OBJECT_TYPES:
                     reported_stats.append(k)
                     reported_stats.append(v)

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -638,7 +638,7 @@ class HTMLReportBuilder(object):
         for obj_id in objs:
             displayable_ids.append(obj_id.replace("_", " "))
             page_name = os.path.join(
-                self.pipeline_reports, (obj_id + ".html").replace(" ", "_").lower()
+                self.pipeline_reports, (obj_id + ".html").replace(" ", "%20").lower()
             )
             relpaths.append(_make_relpath(page_name, wd, context))
         return relpaths, displayable_ids
@@ -650,7 +650,7 @@ class HTMLReportBuilder(object):
             sample_name = sample["record_identifier"]
             page_name = os.path.join(
                 self.pipeline_reports,
-                f"{sample_name}.html".replace(" ", "_").lower(),
+                f"{sample_name}.html".replace(" ", "%20").lower(),
             )
             relpaths.append(_make_relpath(page_name, wd, context))
             sample_names.append(sample_name)


### PR DESCRIPTION

Allow pipestat to use a single result file per sample if given `{record_identifier}` in the result_file_path.

Then, if multiple result files are used, summarize, table, and link will search for the result.yaml files, aggregate them and use the aggregated results.

Related to:
https://github.com/pepkit/pipestat/issues/120
https://github.com/databio/pepatac/issues/257
https://github.com/databio/pepatac/issues/256