### PR TITLE
Allow remote schemas. Fix #160

### DIFF
--- a/pipestat/helpers.py
+++ b/pipestat/helpers.py
@@ -14,8 +14,6 @@ from typing import Any, Dict, Optional, Tuple, Union, List
 from oyaml import safe_load, dump
 from ubiquerg import expandpath, is_url
 
-from zipfile import ZipFile, ZIP_DEFLATED
-
 from .const import (
     PIPESTAT_GENERIC_CONFIG,
     SCHEMA_PROP_KEY,
@@ -100,43 +98,14 @@ def mk_list_of_str(x):
     )
 
 
-def mk_abs_via_cfg(
-    path: Optional[str],
-    cfg_path: Optional[str],
-) -> Optional[str]:
-    """
-    Helper function to ensure a path is absolute.
+def make_subdirectories(path):
+    """Takes an absolute file path and creates subdirectories to file if they do not exist"""
 
-    Assumes a relative path is relative to cfg_path, or to current working directory if cfg_path is None.
-
-    : param str path: The path to make absolute.
-    : param str cfg_path: Relative paths will be relative the containing folder of this path
-    """
-    if path is None:
-        return path
-    if is_url(path):
-        return path
-    assert isinstance(path, str), TypeError("Path is expected to be a str")
-    if os.path.isabs(path):
-        return path
-    if cfg_path is None:
-        rel_to_cwd = os.path.join(os.getcwd(), path)
+    if path:
         try:
-            os.makedirs(os.path.dirname(rel_to_cwd))
+            os.makedirs(os.path.dirname(path))
         except FileExistsError:
             pass
-        if os.path.exists(rel_to_cwd) or os.access(os.path.dirname(rel_to_cwd), os.W_OK):
-            return rel_to_cwd
-        else:
-            raise OSError(f"File not found: {path}")
-    joined = os.path.join(os.path.dirname(cfg_path), path)
-    try:
-        os.makedirs(os.path.dirname(joined))
-    except FileExistsError:
-        pass
-    if os.path.isabs(joined):
-        return joined
-    raise OSError(f"Could not make this path absolute: {path}")
 
 
 def init_generic_config():

--- a/pipestat/helpers.py
+++ b/pipestat/helpers.py
@@ -12,7 +12,7 @@ from shutil import make_archive
 from typing import Any, Dict, Optional, Tuple, Union, List
 
 from oyaml import safe_load, dump
-from ubiquerg import expandpath
+from ubiquerg import expandpath, is_url
 
 from zipfile import ZipFile, ZIP_DEFLATED
 
@@ -110,9 +110,11 @@ def mk_abs_via_cfg(
     Assumes a relative path is relative to cfg_path, or to current working directory if cfg_path is None.
 
     : param str path: The path to make absolute.
-    : param str cfg_path: Relative paths will be relative the containing folder of this pat
+    : param str cfg_path: Relative paths will be relative the containing folder of this path
     """
     if path is None:
+        return path
+    if is_url(path):
         return path
     assert isinstance(path, str), TypeError("Path is expected to be a str")
     if os.path.isabs(path):

--- a/pipestat/parsed_schema.py
+++ b/pipestat/parsed_schema.py
@@ -170,6 +170,7 @@ class ParsedSchema(object):
         :return str: string representation of the object
         """
         res = f"{self.__class__.__name__} ({self._pipeline_name})"
+
         def add_props(props):
             res = ""
             if len(props) == 0:

--- a/pipestat/parsed_schema.py
+++ b/pipestat/parsed_schema.py
@@ -15,7 +15,6 @@ from .const import (
     SCHEMA_TYPE_KEY,
 )
 from .exceptions import SchemaError
-from .helpers import read_yaml_data
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -76,7 +75,6 @@ class ParsedSchema(object):
     def __init__(self, data: Union[Dict[str, Any], Path, str]) -> None:
         # initial validation and parse
         if not isinstance(data, dict):
-            # _, data = read_yaml_data(data, "schema")
             data = yacman.load_yaml(data)
 
         # Keep a copy of the original schema

--- a/pipestat/parsed_schema.py
+++ b/pipestat/parsed_schema.py
@@ -170,19 +170,33 @@ class ParsedSchema(object):
         :return str: string representation of the object
         """
         res = f"{self.__class__.__name__} ({self._pipeline_name})"
+        def add_props(props):
+            res = ""
+            if len(props) == 0:
+                res += "\n - None"
+            else:
+                for k, v in props:
+                    res += f"\n - {k} : {v}"
+            return res
+
         if self._project_level_data is not None:
-            res += "\n Project Level Data:"
-            for k, v in self._project_level_data.items():
-                res += f"\n -  {k} : {v}"
+            res += "\n Project-level properties:"
+            res += add_props(self._project_level_data.items())
         if self._sample_level_data is not None:
-            res += "\n Sample Level Data:"
-            for k, v in self._sample_level_data.items():
-                res += f"\n -  {k} : {v}"
+            res += "\n Sample-level properties:"
+            res += add_props(self._sample_level_data.items())
         if self._status_data is not None:
-            res += "\n Status Data:"
-            for k, v in self._status_data.items():
-                res += f"\n -  {k} : {v}"
+            res += "\n Status properties:"
+            res += add_props(self._status_data.items())
         return res
+
+    def __repr__(self):
+        """
+        Generate string representation of the object.
+
+        :return str: string representation of the object
+        """
+        return self.__str__()
 
     @property
     def pipeline_name(self):

--- a/pipestat/parsed_schema.py
+++ b/pipestat/parsed_schema.py
@@ -4,7 +4,7 @@ import copy
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Union
-
+import yacman
 from .const import (
     CANONICAL_TYPES,
     CLASSES_BY_TYPE,
@@ -76,7 +76,8 @@ class ParsedSchema(object):
     def __init__(self, data: Union[Dict[str, Any], Path, str]) -> None:
         # initial validation and parse
         if not isinstance(data, dict):
-            _, data = read_yaml_data(data, "schema")
+            # _, data = read_yaml_data(data, "schema")
+            data = yacman.load_yaml(data)
 
         # Keep a copy of the original schema
         self.original_schema = copy.deepcopy(data)

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -501,7 +501,7 @@ class PipestatManager(MutableMapping):
         )
 
         if self._schema_path is None:
-            _LOGGER.warning("No schema supplied.")
+            _LOGGER.warning("No pipestat output schema was supplied to PipestatManager.")
             self.cfg[SCHEMA_KEY] = None
             self.cfg[STATUS_SCHEMA_KEY] = None
             self.cfg[STATUS_SCHEMA_SOURCE_KEY] = None

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -10,6 +10,7 @@ from jsonschema import validate
 from yacman import FutureYAMLConfigManager as YAMLConfigManager
 from yacman.yacman_future import select_config
 from ubiquerg import mkabs
+from yacman import load_yaml
 
 
 from typing import Optional, Union, Dict, Any, List, Iterator
@@ -28,7 +29,6 @@ from pipestat.backends.file_backend.filebackend import FileBackend
 from .reports import HTMLReportBuilder, _create_stats_objs_summaries
 from .helpers import (
     validate_type,
-    read_yaml_data,
     default_formatter,
     zip_report,
     make_subdirectories,
@@ -181,7 +181,7 @@ class PipestatManager(MutableMapping):
         else:
             self.cfg[CONFIG_KEY] = YAMLConfigManager()
 
-        _, cfg_schema = read_yaml_data(CFG_SCHEMA, "config schema")
+        cfg_schema = load_yaml(CFG_SCHEMA)
         validate(self.cfg[CONFIG_KEY].exp, cfg_schema)
 
         self.cfg[SCHEMA_PATH] = self.cfg[CONFIG_KEY].priority_get(
@@ -517,10 +517,8 @@ class PipestatManager(MutableMapping):
             # Status schema
             self.cfg[STATUS_SCHEMA_KEY] = parsed_schema.status_data
             if not self.cfg[STATUS_SCHEMA_KEY]:
-                (
-                    self.cfg[STATUS_SCHEMA_SOURCE_KEY],
-                    self.cfg[STATUS_SCHEMA_KEY],
-                ) = read_yaml_data(path=STATUS_SCHEMA, what="default status schema")
+                self.cfg[STATUS_SCHEMA_SOURCE_KEY] = STATUS_SCHEMA
+                self.cfg[STATUS_SCHEMA_KEY] = load_yaml(filepath=STATUS_SCHEMA)
             else:
                 self.cfg[STATUS_SCHEMA_SOURCE_KEY] = schema_to_read
 

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -9,6 +9,8 @@ from collections.abc import MutableMapping
 from jsonschema import validate
 from yacman import FutureYAMLConfigManager as YAMLConfigManager
 from yacman.yacman_future import select_config
+from ubiquerg import mkabs
+
 
 from typing import Optional, Union, Dict, Any, List, Iterator
 
@@ -493,7 +495,7 @@ class PipestatManager(MutableMapping):
         )
 
         if self._schema_path is None:
-            _LOGGER.warning("No pipestat output schema was supplied to PipestatManager.")
+            _LOGGER.warning("No schema supplied.")
             self.cfg[SCHEMA_KEY] = None
             self.cfg[STATUS_SCHEMA_KEY] = None
             self.cfg[STATUS_SCHEMA_SOURCE_KEY] = None
@@ -501,7 +503,7 @@ class PipestatManager(MutableMapping):
             # raise SchemaNotFoundError("PipestatManager creation failed; no schema")
         else:
             # Main schema
-            schema_to_read = mk_abs_via_cfg(self._schema_path, self.cfg["config_path"])
+            schema_to_read = mkabs(self._schema_path, self.cfg["config_path"])
             self._schema_path = schema_to_read
             parsed_schema = ParsedSchema(schema_to_read)
             self.cfg[SCHEMA_KEY] = parsed_schema

--- a/pipestat/pipestat.py
+++ b/pipestat/pipestat.py
@@ -26,7 +26,13 @@ from .exceptions import (
 )
 from pipestat.backends.file_backend.filebackend import FileBackend
 from .reports import HTMLReportBuilder, _create_stats_objs_summaries
-from .helpers import validate_type, mk_abs_via_cfg, read_yaml_data, default_formatter, zip_report
+from .helpers import (
+    validate_type,
+    read_yaml_data,
+    default_formatter,
+    zip_report,
+    make_subdirectories,
+)
 from .const import (
     PKG_NAME,
     DEFAULT_PIPELINE_NAME,
@@ -209,7 +215,7 @@ class PipestatManager(MutableMapping):
             "pipeline_type", default="sample", override=pipeline_type
         )
 
-        self.cfg[FILE_KEY] = mk_abs_via_cfg(
+        self.cfg[FILE_KEY] = mkabs(
             self.resolve_results_file_path(
                 self.cfg[CONFIG_KEY].priority_get(
                     "results_file_path",
@@ -219,6 +225,7 @@ class PipestatManager(MutableMapping):
             ),
             self.cfg["config_path"],
         )
+        make_subdirectories(self.cfg[FILE_KEY])
 
         self.cfg[RESULT_FORMATTER] = result_formatter
 
@@ -343,9 +350,8 @@ class PipestatManager(MutableMapping):
             override=flag_file_dir,
             default=os.path.dirname(self.cfg[FILE_KEY]),
         )
-        self.cfg[STATUS_FILE_DIR] = mk_abs_via_cfg(
-            flag_file_dir, self.config_path or self.cfg[FILE_KEY]
-        )
+        self.cfg[STATUS_FILE_DIR] = mkabs(flag_file_dir, self.config_path or self.cfg[FILE_KEY])
+        make_subdirectories(self.cfg[STATUS_FILE_DIR])
 
         self.backend = FileBackend(
             self.cfg[FILE_KEY],
@@ -815,7 +821,8 @@ class PipestatManager(MutableMapping):
                 results_directory = self.cfg["unresolved_result_path"].split(
                     "{record_identifier}"
                 )[0]
-                results_directory = mk_abs_via_cfg(results_directory, self.cfg["config_path"])
+                results_directory = mkabs(results_directory, self.cfg["config_path"])
+                make_subdirectories(results_directory)
                 self.backend.aggregate_multi_results(results_directory)
 
     @require_backend

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -17,7 +17,8 @@ from logging import getLogger
 from peppy.const import AMENDMENTS_KEY
 from typing import List
 from copy import deepcopy
-from .helpers import mk_abs_via_cfg
+
+from ubiquerg import mkabs
 
 from ._version import __version__
 from .const import (
@@ -34,7 +35,7 @@ from .const import (
     STATUS_FILE_DIR,
     FILE_KEY,
 )
-
+from .helpers import make_subdirectories
 
 _LOGGER = getLogger(PKG_NAME)
 
@@ -509,12 +510,13 @@ class HTMLReportBuilder(object):
 
         if self.prj.cfg["multi_result_files"] is True:
             self.prj.cfg["record_identifier"] = sample_name
-            temp_result_file_path = mk_abs_via_cfg(
+            temp_result_file_path = mkabs(
                 self.prj.resolve_results_file_path(self.prj.cfg["unresolved_result_path"]),
                 self.prj.cfg["config_path"],
             )
+            make_subdirectories(temp_result_file_path)
             self.prj.backend.status_file_dir = os.path.dirname(
-                mk_abs_via_cfg(temp_result_file_path, self.prj.cfg["config_path"])
+                mkabs(temp_result_file_path, self.prj.cfg["config_path"])
             )
 
         flag = self.prj.get_status(record_identifier=sample_name)
@@ -1218,12 +1220,13 @@ def create_status_table(report_obj, project, pipeline_reports_dir: str, portable
             try:
                 if psm.cfg["multi_result_files"] is True:
                     psm.cfg["record_identifier"] = sample_name
-                    temp_result_file_path = mk_abs_via_cfg(
+                    temp_result_file_path = mkabs(
                         psm.resolve_results_file_path(psm.cfg["unresolved_result_path"]),
                         psm.cfg["config_path"],
                     )
+                    make_subdirectories(temp_result_file_path)
                     psm.backend.status_file_dir = os.path.dirname(
-                        mk_abs_via_cfg(temp_result_file_path, psm.cfg["config_path"])
+                        mkabs(temp_result_file_path, psm.cfg["config_path"])
                     )
                 status = psm.get_status(record_identifier=sample_name)
                 statuses.append(status)

--- a/requirements/requirements-all.txt
+++ b/requirements/requirements-all.txt
@@ -1,7 +1,7 @@
 jsonschema
 logmuse>=0.2.5
 oyaml
-ubiquerg>=0.6.1
+ubiquerg>=0.8.0
 yacman>=0.9.3
 pandas
 eido

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -6,7 +6,7 @@ jinja2
 jsonschema
 logmuse>=0.2.5
 oyaml
-ubiquerg>=0.6.1
+ubiquerg>=0.8.0
 yacman>=0.9.2
 PyYAML
 pandas

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import subprocess
 
 from pipestat.const import STATUS_SCHEMA
-from pipestat.helpers import read_yaml_data
+from yacman import load_yaml
 from atexit import register
 
 REC_ID = "constant_record_id"
@@ -51,12 +51,10 @@ def get_data_file_path(filename: str) -> str:
 
 
 # Data corresponding to the non-default status schema info used in a few places in the test data files.
-_, COMMON_CUSTOM_STATUS_DATA = read_yaml_data(
-    path=get_data_file_path("custom_status_schema.yaml"), what="custom test schema data"
-)
+COMMON_CUSTOM_STATUS_DATA = load_yaml(filepath=get_data_file_path("custom_status_schema.yaml"))
 
 # Data corresponding to default status schema, at pipestat/schema/status_schema.yaml
-_, DEFAULT_STATUS_DATA = read_yaml_data(path=STATUS_SCHEMA, what="default status schema")
+DEFAULT_STATUS_DATA = load_yaml(filepath=STATUS_SCHEMA)
 
 
 @pytest.fixture


### PR DESCRIPTION
This allows the schemas to be remote. I did this by using `yacman.load_yaml`, instead of an internal `read_yaml_data` which did not handle URLs. I also replaced an internal `mk_abs_via_cfg` function call with `ubiquerg.mkabs` --

- [x] Should we replace all `mk_abs_via_cfg` use by `mkabs`, and then remove that function?
- [x] Should we replace *all* the calls to the internal `read_yaml_data`with the `yacman.load_yaml`? This would require a bit of refactoring because the internal `read_yaml_data` was not *just* reading yaml, but was used for a few other things as well. In general I don't like that entanglement, and it would reduce maintenance to just use `yacman.load_yaml`.
- [ ] update documentation to make use of this nicety to explain things easier. (for example, here: https://pep.databio.org/pipestat/code/python-tutorial/)

One nice thing about this is that it will make it *so much easier* to get started using pipestat. Our tutorials can just gloss over the schema complexity and point to some general-purposes, training schemas, so then the user doesn't have to create one locally to just get started quickly.


TODO:
- [x] Wait for [ubiquerg 0.8.0 release](https://github.com/pepkit/ubiquerg/pull/41) (this relies on new ubiquerg functionality)

