### PR TITLE
Dev refactor reporting

### DIFF
--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -789,13 +789,14 @@ class HTMLReportBuilder(object):
         )
 
         project_objects = self.create_project_objects()
-        columns = ["Record Identifiers"] + list(sorted_sample_stat_results.keys())
+        columns_table = ["Record Identifiers"] + list(sorted_sample_stat_results.keys())
+        columns_stats = list(sorted_sample_stat_results.keys())
         template_vars = dict(
             navbar=navbar,
             stats_file_path=stats_file_path,
             objs_file_path=objs_file_path,
-            columns=columns,
-            columns_json=dumps(columns),
+            columns=columns_table,
+            columns_json=dumps(columns_stats),
             table_row_data=table_row_data,
             project_name=self.prj.cfg[PROJECT_NAME],
             pipeline_name=self.pipeline_name,
@@ -947,7 +948,7 @@ class HTMLReportBuilder(object):
     def _stats_to_json_str(self):
         results = {}
         if self.prj.cfg["multi_result_files"] is True:
-            pipeline_types = ["sample", "project"]
+            pipeline_types = ["sample"]
         else:
             pipeline_types = [self.prj.backend.pipeline_type]
 

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -704,7 +704,7 @@ class HTMLReportBuilder(object):
             all_result_identifiers = input_sample_attributes + all_result_identifiers
 
         if self.prj.cfg["multi_result_files"] is True:
-            pipeline_types = ["sample", "project"]
+            pipeline_types = ["sample"]
         else:
             pipeline_types = [self.prj.backend.pipeline_type]
 

--- a/pipestat/reports.py
+++ b/pipestat/reports.py
@@ -731,6 +731,15 @@ class HTMLReportBuilder(object):
                     if key not in sample_stat_results.keys():
                         sample_stat_results[key] = ""
 
+                for key in self.schema.keys():
+                    if "type" in self.schema[key]:
+                        if (
+                            self.schema[key]["type"] == "file"
+                            or self.schema[key]["type"] == "image"
+                            or self.schema[key]["type"] == "object"
+                        ):
+                            del sample_stat_results[key]
+
                 # Sort to ensure alignment in the table
                 sorted_sample_stat_results = dict(sorted(sample_stat_results.items()))
 

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -2514,4 +2514,3 @@ class TestRetrieveHistory:
             assert len(history_result.keys()) == 1
             assert "output_image" in history_result
             assert len(history_result["output_image"].keys()) == 2
-

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -2515,35 +2515,3 @@ class TestRetrieveHistory:
             assert "output_image" in history_result
             assert len(history_result["output_image"].keys()) == 2
 
-    @pytest.mark.parametrize("backend", ["file"])
-    def test_temp(
-        self,
-        config_file_path,
-        results_file_path,
-        recursive_schema_file_path,
-        backend,
-        range_values,
-    ):
-        # This is for temporary PEATAC testing for determining summarize function
-        with TemporaryDirectory() as d, ContextManagerDBTesting(DB_URL):
-            temp_dir = d
-            # single_results_file_path = "{record_identifier}/results.yaml"
-            # results_file_path = os.path.join(temp_dir, single_results_file_path)
-            # args = dict(schema_path=recursive_schema_file_path, database_only=False)
-            # n = 3
-            config_file_path = "/home/drc/pepatac_tutorial/processed/looper_pipestat_config.yaml"
-
-            # for i in range_values[:n]:
-            #     r_id = i[0]
-            #     val = i[1]
-            #     backend_data = {"record_identifier": r_id, "results_file_path": results_file_path}
-            #     args.update(backend_data)
-            #     psm = SamplePipestatManager(**args)
-            #     psm.report(record_identifier=r_id, values=val, force_overwrite=True)
-            psm = PipestatManager(config_file=config_file_path)
-            reportlink = psm.summarize()
-            print(reportlink)
-            statstsv = psm.table()
-            print(statstsv)
-            # data = YAMLConfigManager(filepath=os.path.join(temp_dir, "aggregate_results.yaml"))
-            # assert r_id in data[psm.pipeline_name][psm.pipeline_type].keys()

--- a/tests/test_pipestat.py
+++ b/tests/test_pipestat.py
@@ -2514,3 +2514,36 @@ class TestRetrieveHistory:
             assert len(history_result.keys()) == 1
             assert "output_image" in history_result
             assert len(history_result["output_image"].keys()) == 2
+
+    @pytest.mark.parametrize("backend", ["file"])
+    def test_temp(
+        self,
+        config_file_path,
+        results_file_path,
+        recursive_schema_file_path,
+        backend,
+        range_values,
+    ):
+        # This is for temporary PEATAC testing for determining summarize function
+        with TemporaryDirectory() as d, ContextManagerDBTesting(DB_URL):
+            temp_dir = d
+            # single_results_file_path = "{record_identifier}/results.yaml"
+            # results_file_path = os.path.join(temp_dir, single_results_file_path)
+            # args = dict(schema_path=recursive_schema_file_path, database_only=False)
+            # n = 3
+            config_file_path = "/home/drc/pepatac_tutorial/processed/looper_pipestat_config.yaml"
+
+            # for i in range_values[:n]:
+            #     r_id = i[0]
+            #     val = i[1]
+            #     backend_data = {"record_identifier": r_id, "results_file_path": results_file_path}
+            #     args.update(backend_data)
+            #     psm = SamplePipestatManager(**args)
+            #     psm.report(record_identifier=r_id, values=val, force_overwrite=True)
+            psm = PipestatManager(config_file=config_file_path)
+            reportlink = psm.summarize()
+            print(reportlink)
+            statstsv = psm.table()
+            print(statstsv)
+            # data = YAMLConfigManager(filepath=os.path.join(temp_dir, "aggregate_results.yaml"))
+            # assert r_id in data[psm.pipeline_name][psm.pipeline_type].keys()


### PR DESCRIPTION
This addresses #150 and #148, when using the reporting mechanism to display both sample-level and project-level results together in the same report.

The fixes required fewer changes than originally envisioned!

![image](https://github.com/pepkit/pipestat/assets/125581724/2db67bef-7088-4019-a73e-b9637eb0a09c)

The tables now only show sample-level, stats results.

The project-level record, `summary`, still shows up in the drop-down menu for easy access:
![image](https://github.com/pepkit/pipestat/assets/125581724/b31d88c4-c898-4069-807a-a84008a3ca5d)

Objects are no longer reported in the table but they can be found in the objects drop-down:
![image](https://github.com/pepkit/pipestat/assets/125581724/bd5e2a18-5394-4801-af60-062c8df82848)

